### PR TITLE
STCOR-511: Add locateCssVariables to postcss-loader loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Change history for stripes-webpack
+
+## 1.0.0 IN PROGRESS
+
+* Add `locateCssVariables` to `postcss-loader` loader. Refs STCOR-511.

--- a/webpack.config.cli.dev.js
+++ b/webpack.config.cli.dev.js
@@ -11,10 +11,21 @@ const postCssNesting = require('postcss-nesting');
 const postCssCustomMedia = require('postcss-custom-media');
 const postCssMediaMinMax = require('postcss-media-minmax');
 const postCssColorFunction = require('postcss-color-function');
-const { generateStripesAlias } = require('./webpack/module-paths');
+const { generateStripesAlias, tryResolve } = require('./webpack/module-paths');
 
 const base = require('./webpack.config.base');
 const cli = require('./webpack.config.cli');
+
+const locateCssVariables = () => {
+  const variables = 'lib/variables.css';
+  const localPath = path.join(path.resolve(), variables);
+
+  // check if variables are present locally (in cases when stripes-components is
+  // being built directly) if not look for them via stripes aliases
+  return tryResolve(localPath) ?
+    localPath :
+    path.join(generateStripesAlias('@folio/stripes-components'), variables);
+};
 
 const devConfig = Object.assign({}, base, cli, {
   devtool: 'inline-source-map',
@@ -56,7 +67,7 @@ devConfig.module.rules.push({
           autoprefixer(),
           postCssCustomProperties({
             preserve: false,
-            importFrom: [path.join(generateStripesAlias('@folio/stripes-components'), 'lib/variables.css')]
+            importFrom: [locateCssVariables()]
           }),
           postCssCalc(),
           postCssNesting(),


### PR DESCRIPTION
When building and testing stripes-components directly the `node_modules/stripes-components` is not present which caused issues when looking for css variables via `generateStripesAlias`.

This PR introduces `locateCssVariables` to also look for `lib/variables.css` in the local folder. 

Thank you @zburke for finding and coming with a solution for this issue.

https://issues.folio.org/browse/STCOR-511