### PR TITLE
STRWEB-1 remove hard-source-webpack-plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change history for stripes-webpack
 
-## 1.0.0 IN PROGRESS
+## 1.1.0 IN PROGRESS
 
+* Remove support for `hardsource-webpack-plugin`. Refs STCOR-421, STCOR-510.
 * Add `locateCssVariables` to `postcss-loader` loader. Refs STCOR-511.


### PR DESCRIPTION
This ports https://github.com/folio-org/stripes-core/pull/1006 from
`stripes-core` to `stripes-webpack`, which was cleaved from
`stripes-core` just before that PR merged.

Refs [STRWEB-1](https://issues.folio.org/browse/STRWEB-1), [STCOR-421](https://issues.folio.org/browse/STCOR-421)