### PR TITLE
STRWEB-2 provide errorLogging plugin

### DIFF
--- a/test/webpack/stripes-config-plugin.spec.js
+++ b/test/webpack/stripes-config-plugin.spec.js
@@ -4,6 +4,7 @@ const VirtualModulesPlugin = require('webpack-virtual-modules');
 const StripesConfigPlugin = require('../../webpack/stripes-config-plugin');
 const StripesTranslationsPlugin = require('../../webpack/stripes-translations-plugin');
 const StripesBrandingPlugin = require('../../webpack/stripes-branding-plugin');
+const StripesErrorLoggingPlugin = require('../../webpack/stripes-error-logging-plugin');
 const stripesModuleParser = require('../../webpack/stripes-module-parser');
 const stripesSerialize = require('../../webpack/stripes-serialize');
 
@@ -112,6 +113,10 @@ describe('The stripes-config-plugin', function () {
       brandingPlugin.serializedBranding = JSON.stringify({ logo: { alt: 'Future Of Libraries Is Open' } });
       compilerStub.options.plugins.push(brandingPlugin);
 
+      const loggingPlugin = new StripesErrorLoggingPlugin({});
+      loggingPlugin.errorLogging = JSON.stringify({ loggingService: { apiKey: 'top-secret' } });
+      compilerStub.options.plugins.push(loggingPlugin);
+
       this.sut.apply(compilerStub);
     });
 
@@ -130,7 +135,7 @@ describe('The stripes-config-plugin', function () {
       expect(writeModuleArgs[0]).to.be.a('string').that.equals('node_modules/stripes-config.js');
 
       // TODO: More thorough analysis of the generated virtual module
-      expect(writeModuleArgs[1]).to.be.a('string').with.match(/export { okapi, config, modules, branding, translations, metadata, icons }/);
+      expect(writeModuleArgs[1]).to.be.a('string').with.match(/export { okapi, config, modules, branding, errorLogging, translations, metadata, icons }/);
     });
   });
 

--- a/test/webpack/stripes-webpack-plugin.spec.js
+++ b/test/webpack/stripes-webpack-plugin.spec.js
@@ -4,6 +4,7 @@ const StripesWebpackPlugin = require('../../webpack/stripes-webpack-plugin');
 const StripesConfigPlugin = require('../../webpack/stripes-config-plugin');
 const StripesTranslationsPlugin = require('../../webpack/stripes-translations-plugin');
 const StripesBrandingPlugin = require('../../webpack/stripes-branding-plugin');
+const StripesErrorLoggingPlugin = require('../../webpack/stripes-error-logging-plugin');
 const StripesDuplicatesPlugin = require('../../webpack/stripes-duplicate-plugin');
 
 const compilerStub = {
@@ -43,6 +44,7 @@ describe('The stripes-webpack-plugin', function () {
     beforeEach(function () {
       this.sandbox.stub(StripesConfigPlugin.prototype, 'apply').callsFake(() => {});
       this.sandbox.stub(StripesBrandingPlugin.prototype, 'apply').callsFake(() => {});
+      this.sandbox.stub(StripesErrorLoggingPlugin.prototype, 'apply').callsFake(() => {});
       this.sandbox.stub(StripesTranslationsPlugin.prototype, 'apply').callsFake(() => {});
       this.sandbox.stub(StripesDuplicatesPlugin.prototype, 'apply').callsFake(() => {});
       this.sut = new StripesWebpackPlugin({ stripesConfig: mockConfig });
@@ -62,6 +64,12 @@ describe('The stripes-webpack-plugin', function () {
       this.sut.apply(compilerStub);
       expect(StripesBrandingPlugin.prototype.apply).to.have.been.calledOnce;
       expect(StripesBrandingPlugin.prototype.apply).to.be.calledWith(compilerStub);
+    });
+
+    it('applies StripesErrorLoggingPlugin', function () {
+      this.sut.apply(compilerStub);
+      expect(StripesErrorLoggingPlugin.prototype.apply).to.have.been.calledOnce;
+      expect(StripesErrorLoggingPlugin.prototype.apply).to.be.calledWith(compilerStub);
     });
 
     it('applies StripesTranslationsPlugin', function () {

--- a/webpack/stripes-config-plugin.js
+++ b/webpack/stripes-config-plugin.js
@@ -21,7 +21,7 @@ module.exports = class StripesConfigPlugin {
     if (!_.isObject(options.modules)) {
       throw new StripesBuildError('stripes-config-plugin was not provided a "modules" object for enabling stripes modules');
     }
-    this.options = _.omit(options, 'branding');
+    this.options = _.omit(options, 'branding', 'errorLogging');
   }
 
   apply(compiler) {
@@ -55,6 +55,7 @@ module.exports = class StripesConfigPlugin {
     // Data provided by other stripes plugins via hooks
     const pluginData = {
       branding: {},
+      errorLogging: {},
       translations: {},
     };
     compiler.hooks.stripesConfigPluginBeforeWrite.call(pluginData);
@@ -63,10 +64,11 @@ module.exports = class StripesConfigPlugin {
     const stripesVirtualModule = `
       const { okapi, config, modules } = ${serialize(this.mergedConfig, { space: 2 })};
       const branding = ${stripesSerialize.serializeWithRequire(pluginData.branding)};
+      const errorLogging = ${stripesSerialize.serializeWithRequire(pluginData.errorLogging)};
       const translations = ${serialize(pluginData.translations, { space: 2 })};
       const metadata = ${stripesSerialize.serializeWithRequire(this.metadata)};
       const icons = ${stripesSerialize.serializeWithRequire(this.icons)};
-      export { okapi, config, modules, branding, translations, metadata, icons };
+      export { okapi, config, modules, branding, errorLogging, translations, metadata, icons };
     `;
 
     logger.log('writing virtual module...', stripesVirtualModule);

--- a/webpack/stripes-error-logging-plugin.js
+++ b/webpack/stripes-error-logging-plugin.js
@@ -1,0 +1,23 @@
+// This webpack plugin generates a virtual module containing the
+// error-logging configuration.
+
+const logger = require('./logger')('stripesErrorLoggingPlugin');
+
+module.exports = class StripesErrorLoggingPlugin {
+  constructor(options) {
+    logger.log('initializing...');
+
+    const defaultErrorLogging = {};
+
+    const tenantErrorLogging = (options && options.tenantErrorLogging) ? options.tenantErrorLogging : {};
+    this.errorLogging = Object.assign({}, defaultErrorLogging, tenantErrorLogging);
+  }
+
+  apply(compiler) {
+    // Hook into stripesConfigPlugin to supply errorLogging config
+    compiler.hooks.stripesConfigPluginBeforeWrite.tap('StripesErrorLoggingPlugin', (config) => {
+      config.errorLogging = this.errorLogging;
+      logger.log('stripesConfigPluginBeforeWrite', config.errorLogging);
+    });
+  }
+};

--- a/webpack/stripes-webpack-plugin.js
+++ b/webpack/stripes-webpack-plugin.js
@@ -2,6 +2,7 @@
 
 const StripesConfigPlugin = require('./stripes-config-plugin');
 const StripesBrandingPlugin = require('./stripes-branding-plugin');
+const StripesErrorLoggingPlugin = require('./stripes-error-logging-plugin');
 const StripesTranslationsPlugin = require('./stripes-translations-plugin');
 const StripesDuplicatesPlugin = require('./stripes-duplicate-plugin');
 const logger = require('./logger')('stripesWebpackPlugin');
@@ -26,6 +27,10 @@ module.exports = class StripesWebpackPlugin {
       stripesPlugins.push(new StripesBrandingPlugin({
         tenantBranding: this.stripesConfig.branding,
         buildAllFavicons: isProduction,
+      }));
+
+      stripesPlugins.push(new StripesErrorLoggingPlugin({
+        tenantErrorLogging: this.stripesConfig.errorLogging,
       }));
     }
 


### PR DESCRIPTION
Pass `errorLogging` values from a `stripes.config.js` file into the
dynamically generated config module.

This is cribbed from https://github.com/folio-org/stripes-core/pull/1004, which did two things: 

1. publishing of error events
2. a webpack config to accept error-logging values via `stripes.config.js`

Now that webpacky things have been externalized here from `stripes-core`, this PR implements Part 2. 

Refs [STRWEB-2](https://issues.folio.org/browse/STRWEB-2)