### PR TITLE
STRWEB-1 remove hard-source-webpack-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "favicons-webpack-plugin": "^3.0.1",
     "file-loader": "^1.1.11",
     "handlebars-loader": "^1.7.1",
-    "hard-source-webpack-plugin": "^0.12.0",
     "html-webpack-plugin": "^4.0.0-beta.10",
     "lodash-webpack-plugin": "^0.11.5",
     "mini-css-extract-plugin": "^0.4.0",


### PR DESCRIPTION
Replaces #5, which somehow only contains a CHANGELOG entry but, uh, no
actual changes. I dunno what happened there.

Refs [STRWEB-1](https://issues.folio.org/browse/STRWEB-1)