### PR TITLE
really REALLY remove hard-source-webpack-plugin

### DIFF
--- a/webpack/serve.js
+++ b/webpack/serve.js
@@ -1,5 +1,4 @@
 const webpack = require('webpack');
-const HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 const path = require('path');
 const nodeObjectHash = require('node-object-hash');
 const express = require('express');
@@ -14,17 +13,6 @@ const cwd = path.resolve();
 const platformModulePath = path.join(cwd, 'node_modules');
 const coreModulePath = path.join(__dirname, '..', 'node_modules');
 const serverRoot = path.join(__dirname, '..');
-
-const cachePlugin = new HardSourceWebpackPlugin({
-  cacheDirectory: path.join(cwd, 'webpackcache'),
-  recordsPath: path.join(cwd, 'webpackcache/records.json'),
-  configHash(webpackConfig) {
-    // Build a string value used by HardSource to determine which cache to
-    // use if [confighash] is in cacheDirectory or if the cache should be
-    // replaced if [confighash] does not appear in cacheDirectory.
-    return nodeObjectHash().hash(webpackConfig);
-  },
-});
 
 module.exports = function serve(stripesConfig, options) {
   if (typeof stripesConfig.okapi !== 'object') throw new Error('Missing Okapi config');
@@ -41,9 +29,6 @@ module.exports = function serve(stripesConfig, options) {
     config.resolve.modules = ['node_modules', platformModulePath, coreModulePath];
     config.resolveLoader = { modules: ['node_modules', platformModulePath, coreModulePath] };
 
-    if (options.cache) {
-      config.plugins.push(cachePlugin);
-    }
     if (options.devtool) {
       config.devtool = options.devtool;
     }


### PR DESCRIPTION
I don't know why I have struggled SO HARD to port this simple PR from
`stripes-core`, [where it was flawless](https://github.com/folio-org/stripes-core/pull/1006), to `stripes-webpack`, where I have
tried (#5) and tried again (#9) to do the exact same thing but I keep
screwing it up. Maybe `stripes-webpack` is jealous of the nice song?

I want to build without warnings
I want to `yarn` with no old deps
I want to see naked, that terminal
That console, so true errors shine through
@skomorokh put this in here
So now what, so now what?

Wanting, needing, waiting
Will this decruftify my build? (my build)
Hoping, praying
Will this decruftify my build?

I run it local
Not like `--cache`
I don't want an ancient devdep
I don't want abandoned devdeps either
I just want to run `yarn` cleanly
exit zero, `yarn outdated`?
ZERO, that's right, zero.

Wanting, needing, waiting
Can this decruftify my build?
Yearning, burning
Please help decrutify my build.

Refs [STRWEB-1](https://issues.folio.org/browse/STRWEB-1)