### PR TITLE
STRWEB-5: Add support for new jsx transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-webpack
 
+## [1.2.0] IN PROGRESS
+
+* Add support for new jsx transform. Refs STRWEB-5.
+
 ## [1.1.0](https://github.com/folio-org/stripes-webpack/tree/v1.1.0) (2021-02-03)
 
 * Remove support for `hardsource-webpack-plugin`. Refs STCOR-421, STCOR-510.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-webpack",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "The webpack config for stripes",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -13,7 +13,7 @@
     "node": ">=10.0.0"
   },
   "dependencies": {
-    "@babel/core": "^7.8.0",
+    "@babel/core": "^7.9.0",
     "@babel/plugin-proposal-class-properties": "^7.0.0",
     "@babel/plugin-proposal-decorators": "^7.0.0",
     "@babel/plugin-proposal-export-namespace-from": "^7.0.0",
@@ -23,7 +23,7 @@
     "@babel/plugin-syntax-import-meta": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-flow": "^7.7.4",
-    "@babel/preset-react": "^7.7.4",
+    "@babel/preset-react": "^7.9.0",
     "@babel/preset-typescript": "^7.7.7",
     "@babel/register": "^7.0.0",
     "@bigtest/mirage": "^0.0.1",

--- a/webpack/babel-loader-rule.js
+++ b/webpack/babel-loader-rule.js
@@ -30,7 +30,9 @@ module.exports = {
     presets: [
       ['@babel/preset-env', { targets: '> 0.25%, not dead' }],
       ['@babel/preset-flow', { all: true }],
-      ['@babel/preset-react'],
+      ['@babel/preset-react', {
+        "runtime": "automatic"
+      }],
       ['@babel/preset-typescript'],
     ],
     plugins: [


### PR DESCRIPTION
Add support for a new JSX transform which will allow for writing functional components without importing react.

https://issues.folio.org/browse/STRWEB-5

More info:

https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html