### PR TITLE
Added handling for pulling compiled AST translations into final bundle.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-webpack
 
+## [1.2.0](https://github.com/folio-org/stripes-webpack/tree/v1.2.0) (2021-04-05)
+
+* If translations exist in a `/compiled` subdirectory, then they will be preferred as the translations to use in the final bundle. Refs STCLI-158.
+
 ## [1.1.0](https://github.com/folio-org/stripes-webpack/tree/v1.1.0) (2021-02-03)
 
 * Remove support for `hardsource-webpack-plugin`. Refs STCOR-421, STCOR-510.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-webpack",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "The webpack config for stripes",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/webpack/stripes-translations-plugin.js
+++ b/webpack/stripes-translations-plugin.js
@@ -107,6 +107,11 @@ module.exports = class StripesTranslationPlugin {
 
   // Load translation *.json files from a single module's translation directory
   loadTranslationsDirectory(moduleName, dir) {
+    // Load compiled translations if they exist, mixing compiled and uncompiled is acceptable in the final output.
+    if (fs.existsSync(`${dir}/compiled`)) {
+      dir += '/compiled';
+    }
+
     logger.log('loading translations from directory', dir);
     const moduleTranslations = {};
 


### PR DESCRIPTION
If translations exist in a /compiled subdirectory, then they will be preferred as the translations to use in the final bundle. Mixed compiled and uncompiled is acceptable and verified to work correctly at run-time