### PR TITLE
STRWEB-7 ignore non-file entries in translations directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add support for new jsx transform. Refs STRWEB-5.
 * If translations exist in a `/compiled` subdirectory, then they will be preferred as the translations to use in the final bundle. Refs STCLI-158.
+* Ignore non-file entries when reading the `translations/...` directory. Refs STRWEB-7.
 
 ## [1.1.0](https://github.com/folio-org/stripes-webpack/tree/v1.1.0) (2021-02-03)
 

--- a/test/webpack/stripes-translations-plugin.spec.js
+++ b/test/webpack/stripes-translations-plugin.spec.js
@@ -71,7 +71,20 @@ describe('The stripes-translations-plugin', function () {
     beforeEach(function () {
       this.sandbox.stub(modulePaths, 'locateStripesModule').callsFake((context, mod) => `path/to/${mod}/package.json`);
       this.sandbox.stub(fs, 'existsSync').returns(true);
-      this.sandbox.stub(fs, 'readdirSync').returns(['en.json', 'es.json', 'fr.json']);
+      this.sandbox.stub(fs, 'readdirSync').returns([
+        {
+          isFile: () => true,
+          name: 'en.json',
+        },
+        {
+          isFile: () => true,
+          name: 'es.json',
+        },
+        {
+          isFile: () => true,
+          name: 'fr.json',
+        },
+      ]);
       this.sandbox.spy(webpack.ContextReplacementPlugin.prototype, 'apply');
       this.sandbox.spy(compilerStub.hooks.emit, 'tapAsync');
       this.sandbox.stub(StripesTranslationsPlugin, 'loadFile').returns({ key1: 'Value 1', key2: 'Value 2' });
@@ -145,7 +158,20 @@ describe('The stripes-translations-plugin', function () {
 
   describe('loadTranslationsDirectory method', function () {
     beforeEach(function () {
-      this.sandbox.stub(fs, 'readdirSync').returns(['en.json', 'es.json', 'fr.json']);
+      this.sandbox.stub(fs, 'readdirSync').returns([
+        {
+          isFile: () => true,
+          name: 'en.json',
+        },
+        {
+          isFile: () => true,
+          name: 'es.json',
+        },
+        {
+          isFile: () => true,
+          name: 'fr.json',
+        },
+      ]);
       this.sandbox.stub(StripesTranslationsPlugin, 'loadFile').returns({ key1: 'Value 1', key2: 'Value 2' });
       this.sut = new StripesTranslationsPlugin(this.stripesConfig);
     });

--- a/webpack/stripes-translations-plugin.js
+++ b/webpack/stripes-translations-plugin.js
@@ -99,7 +99,7 @@ module.exports = class StripesTranslationPlugin {
           }
         }
       } else {
-        console.log(`Unable to locate ${mod} while looking for translations.`);
+        logger.log(`Unable to locate ${mod} while looking for translations.`);
       }
     }
     return allTranslations;
@@ -122,12 +122,16 @@ module.exports = class StripesTranslationPlugin {
       enTranslations = StripesTranslationPlugin.prefixModuleKeys(moduleName, rawEnTranslations);
     }
 
-    for (const translationFile of fs.readdirSync(dir)) {
-      const language = translationFile.replace('.json', '');
+    for (const translationFile of fs.readdirSync(dir, { withFileTypes: true })) {
+      const language = translationFile.name.replace('.json', '');
       // When filter is set, skip other languages. Otherwise loads all
       if (!this.languageFilter.length || this.languageFilter.includes(language)) {
-        const translations = StripesTranslationPlugin.loadFile(path.join(dir, translationFile));
-        moduleTranslations[language] = Object.assign({}, enTranslations, StripesTranslationPlugin.prefixModuleKeys(moduleName, translations));
+        if (translationFile.isFile()) {
+          const translations = StripesTranslationPlugin.loadFile(path.join(dir, translationFile.name));
+          moduleTranslations[language] = Object.assign({}, enTranslations, StripesTranslationPlugin.prefixModuleKeys(moduleName, translations));
+        } else {
+          logger.log(`Could not read translations from ${path.join(dir, translationFile.name)}; it is not a file.`)
+        }
       }
     }
     return moduleTranslations;


### PR DESCRIPTION
Previously, if the `translations/${module}/` directory contained
accidental non-file cruft (i.e., it contained a directory), the
translations plugin would attempt to read those entries as files.
Predictably, this would fail. Such entries are now ignored and logged.

Refs [STRWEB-7](https://issues.folio.org/browse/STRWEB-7)

Attn: @AndrewIsh