### PR TITLE
STRWEB-11 correctly specify peerDependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-webpack
 
+## 1.3.0 (IN PROGRESS)
+
+* Correctly specify peer-dependencies. Refs STRWEB-11.
+
 ## [1.2.0](https://github.com/folio-org/stripes-webpack/tree/v1.2.0) (2021-04-12)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v1.1.0...v1.2.0)
 

--- a/package.json
+++ b/package.json
@@ -84,5 +84,9 @@
     "mocha-junit-reporter": "^1.17.0",
     "sinon": "^7.3.2",
     "sinon-chai": "^3.3.0"
+  },
+  "peerDependencies": {
+    "react": "^16.14.0",
+    "react-dom": "^16.14.0"
   }
 }


### PR DESCRIPTION
Provide `react` and `react-dom`, peer-deps of `react-hot-loader` among
others, in order to be able to install with `npm` `^7` without requiring
`--legacy-peer-deps`. Without specifying this, the react-dom version
would float to `17.0.2`, which conflicts with other libraries that do
not yet support `react` `^17`.

Refs [STRWEB-11](https://issues.folio.org/browse/STRWEB-11)