### PR TITLE
STRWEB-12 consistently configure babel plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.3.0 (IN PROGRESS)
 
 * Correctly specify peer-dependencies. Refs STRWEB-11.
+* Some babel plugins must be configured consistently. Refs STRWEB-12.
 
 ## [1.2.0](https://github.com/folio-org/stripes-webpack/tree/v1.2.0) (2021-04-12)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v1.1.0...v1.2.0)

--- a/webpack/babel-loader-rule.js
+++ b/webpack/babel-loader-rule.js
@@ -37,7 +37,16 @@ module.exports = {
     ],
     plugins: [
       ['@babel/plugin-proposal-decorators', { 'legacy': true }],
+      // when building a platform directly, i.e. outside a workspace,
+      // babel complains loudly and repeatedly that when these modules are enabled:
+      // * @babel/plugin-proposal-class-properties,
+      // * @babel/plugin-proposal-private-methods and
+      // * @babel/plugin-proposal-private-property-in-object
+      // the "loose" option must be the same for all three.
+      // but @babel/preset-env sets it to false for ...private-methods.
+      // overriding it here silences the complaint. STRWEB-12
       ['@babel/plugin-proposal-class-properties', { 'loose': true }],
+      ['@babel/plugin-proposal-private-methods', { 'loose': true }],
       '@babel/plugin-proposal-export-namespace-from',
       '@babel/plugin-proposal-function-sent',
       '@babel/plugin-proposal-numeric-separator',


### PR DESCRIPTION
Some babel plugins must be configured consistently if they are enabled.
If they aren't, babel warns you loudly and repeatedly when building a
platform independently, i.e. outside a workspace:
```
Though the "loose" option was set to "false" in your @babel/preset-env config, 
it will not be used for @babel/plugin-proposal-private-methods since the "loose" 
mode option was set to "true" for @babel/plugin-proposal-class-properties.
The "loose" option must be the same for @babel/plugin-proposal-class-properties,
@babel/plugin-proposal-private-methods and 
@babel/plugin-proposal-private-property-in-object (when they are enabled): 
you can silence this warning by explicitly adding
        ["@babel/plugin-proposal-private-methods", { "loose": true }]
to the "plugins" section of your Babel config.
```

Refs [STRWEB-12](https://issues.folio.org/browse/STRWEB-12)