### PR TITLE
STRWEB-13 Allow non-@folio modules to be transpiled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Correctly specify peer-dependencies. Refs STRWEB-11.
 * Replace unmaintained `awesome-typescript-loader` with `ts-loader`. Refs STRWEB-10.
 * Some babel plugins must be configured consistently. Refs STRWEB-12.
+* Introduce the STRIPES_TRANSPILE_TOKENS environment variable which includes a space delimited list of strings (typically namespaces) to use in addition to "@folio" to determine if something needs Stripes-flavoured transpilation. Fixes STRWEB-13.
 
 ## [1.2.0](https://github.com/folio-org/stripes-webpack/tree/v1.2.0) (2021-04-12)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v1.1.0...v1.2.0)
@@ -13,7 +14,6 @@
 * If translations exist in a `/compiled` subdirectory, then they will be preferred as the translations to use in the final bundle. Refs STCLI-158.
 * Ignore non-file entries when reading the `translations/...` directory. Refs STRWEB-7.
 * Add support for loading CSV files. Fixes STRWEB-8.
-* Introduce the STRIPES_TRANSPILE_TOKENS environment variable which includes a space delimited list of strings (typically namespaces) to use in addition to "@folio" to determine if something needs Stripes-flavoured transpilation. Fixes STRWEB-13.
 
 ## [1.1.0](https://github.com/folio-org/stripes-webpack/tree/v1.1.0) (2021-02-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * If translations exist in a `/compiled` subdirectory, then they will be preferred as the translations to use in the final bundle. Refs STCLI-158.
 * Ignore non-file entries when reading the `translations/...` directory. Refs STRWEB-7.
 * Add support for loading CSV files. Fixes STRWEB-8.
+* Introduce the STRIPES_TRANSPILE_TOKENS environment variable which includes a space delimited list of strings (typically namespaces) to use in addition to "@folio" to determine if something needs Stripes-flavoured transpilation. Fixes STRWEB-13.
 
 ## [1.1.0](https://github.com/folio-org/stripes-webpack/tree/v1.1.0) (2021-02-03)
 

--- a/webpack/babel-loader-rule.js
+++ b/webpack/babel-loader-rule.js
@@ -16,7 +16,7 @@ const folioScopeBlacklist = [
 function babelLoaderTest(fileName) {
   const nodeModIdx = fileName.lastIndexOf('node_modules');
   if (fileName.endsWith('.js')
-    && (nodeModIdx === -1 || ['@folio', ...extraTranspile].reduce((acc, cur) => (fileName.lastIndexOf(cur) > nodeModIdx) || acc))
+    && (nodeModIdx === -1 || ['@folio', ...extraTranspile].reduce((acc, cur) => (fileName.lastIndexOf(cur) > nodeModIdx) || acc, false))
     && (folioScopeBlacklist.findIndex(ignore => fileName.includes(ignore)) === -1)) {
     return true;
   }

--- a/webpack/babel-loader-rule.js
+++ b/webpack/babel-loader-rule.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const extraTranspile = process.env.STRIPES_TRANSPILE_TOKENS ? process.env.STRIPES_TRANSPILE_TOKENS.split(' ') : [];
 
 // These modules are already transpiled and should be excluded
 const folioScopeBlacklist = [
@@ -15,7 +16,7 @@ const folioScopeBlacklist = [
 function babelLoaderTest(fileName) {
   const nodeModIdx = fileName.lastIndexOf('node_modules');
   if (fileName.endsWith('.js')
-    && (nodeModIdx === -1 || fileName.lastIndexOf('@folio') > nodeModIdx)
+    && (nodeModIdx === -1 || ['@folio', ...extraTranspile].reduce((acc, cur) => (fileName.lastIndexOf(cur) > nodeModIdx) || acc))
     && (folioScopeBlacklist.findIndex(ignore => fileName.includes(ignore)) === -1)) {
     return true;
   }

--- a/webpack/babel-loader-rule.js
+++ b/webpack/babel-loader-rule.js
@@ -1,4 +1,7 @@
 const path = require('path');
+
+// a space delimited list of strings (typically namespaces) to use in addition
+// to "@folio" to determine if something needs Stripes-flavoured transpilation
 const extraTranspile = process.env.STRIPES_TRANSPILE_TOKENS ? process.env.STRIPES_TRANSPILE_TOKENS.split(' ') : [];
 
 // These modules are already transpiled and should be excluded
@@ -6,13 +9,21 @@ const folioScopeBlacklist = [
   'react-githubish-mentions',
 ].map(segment => path.join('@folio', segment));
 
-// We want to transpile files inside node_modules/@folio or outside
-// any node_modules directory. And definitely not files in
-// node_modules outside the @folio namespace even if some parent
-// directory happens to be in @folio.
+// Packages on NPM are typically distributed already transpiled. For historical
+// reasons, Stripes modules are not and have their babel config centralised
+// here. This ought to have changed by now, but for now the following logic is
+// in effect and modules will be transpiled if:
 //
-// fn is the path after all symlinks are resolved so we need to be
-// wary of all the edge cases yarn link will find for us.
+// * they are in the @folio namespace
+// * their name contains a string from STRIPES_TRANSPILE_TOKENS
+//   (typically other namespaces)
+// * they aren't in node_modules (typically in a workspace)
+//
+// You'll see some chicanery here: we are only interested in these strings if
+// they occur after the last instance of "node_modules" since, in some
+// situations, our dependencies will get their own node_modules directories and
+// while we want to transpile "@folio/ui-users/somefile.js" we don't want to
+// transpile "@folio/ui-users/node_modules/nightmare/somefile.js"
 function babelLoaderTest(fileName) {
   const nodeModIdx = fileName.lastIndexOf('node_modules');
   if (fileName.endsWith('.js')


### PR DESCRIPTION
Introduces the STRIPES_TRANSPILE_TOKENS environment variable which
includes a space delimited list of strings (typically namespaces) to use
in addition to "@folio" to determine if something needs
Stripes-flavoured transpilation.

https://issues.folio.org/browse/STRWEB-13
