### PR TITLE
STRWEB-15 avoid buggy optimize-css-assets-webpack-plugin 5.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Replace unmaintained `awesome-typescript-loader` with `ts-loader`. Refs STRWEB-10.
 * Some babel plugins must be configured consistently. Refs STRWEB-12.
 * Introduce the STRIPES_TRANSPILE_TOKENS environment variable which includes a space delimited list of strings (typically namespaces) to use in addition to "@folio" to determine if something needs Stripes-flavoured transpilation. Fixes STRWEB-13.
+* Depend on `optimize-css-assets-webpack-plugin` `^5.0.6` to avoid (reverted) breaking changes in `5.0.5`. Refs STRWEB-15.
 
 ## [1.2.0](https://github.com/folio-org/stripes-webpack/tree/v1.2.0) (2021-04-12)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v1.1.0...v1.2.0)

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lodash-webpack-plugin": "^0.11.5",
     "mini-css-extract-plugin": "^0.4.0",
     "node-object-hash": "^1.2.0",
-    "optimize-css-assets-webpack-plugin": "^5.0.0",
+    "optimize-css-assets-webpack-plugin": "^5.0.6",
     "postcss": "^7.0.2",
     "postcss-calc": "^6.0.0",
     "postcss-color-function": "^4.0.0",


### PR DESCRIPTION
Depend on `^5.0.6` to avoid the breaking changes that were accidentally
introduced in `5.0.5` and then reverted in `5.0.6`.

Refs [STRWEB-15](https://issues.folio.org/browse/STRWEB-15)