### PR TITLE
STRWEB-19 avoid buggy optimize-css-assets-webpack-plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-webpack
 
+## 1.3.0 IN PROGRESS
+
+* Lock onto `optimize-css-assets-webpack-plugin` `5.0.6` to avoid `postcss` `v8`. Fixes STRWEB-19.
+
 ## [1.3.0](https://github.com/folio-org/stripes-webpack/tree/v1.3.0) (2021-06-08)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v1.2.0...v1.3.0)
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lodash-webpack-plugin": "^0.11.5",
     "mini-css-extract-plugin": "^0.4.0",
     "node-object-hash": "^1.2.0",
-    "optimize-css-assets-webpack-plugin": "^5.0.6",
+    "optimize-css-assets-webpack-plugin": "5.0.6",
     "postcss": "^7.0.2",
     "postcss-calc": "^6.0.0",
     "postcss-color-function": "^4.0.0",


### PR DESCRIPTION
Avoid `postcss` `v8`, inadvertently introduced in a patch version (see
https://github.com/NMFR/optimize-css-assets-webpack-plugin/issues/167).

Refs [STRWEB-19](https://issues.folio.org/browse/STRWEB-19)