### PR TITLE
STRWEB-22 export babel config options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Lock onto `optimize-css-assets-webpack-plugin` `5.0.6` to avoid `postcss` `v8`. Fixes STRWEB-19.
 * Add `loose` to `plugin-proposal-private-property-in-object`. Fixes STRWEB-21.
-* Export babel config options for consumption by other modules. Refs STRWEB-22, STRIPES-742.
+* Export babel config options for consumption by other modules. Refs STRWEB-22, STRIPES-742, STRIPES-757.
 
 ## [1.3.0](https://github.com/folio-org/stripes-webpack/tree/v1.3.0) (2021-06-08)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v1.2.0...v1.3.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Change history for stripes-webpack
 
-## 1.3.0 IN PROGRESS
+## 1.4.0 IN PROGRESS
 
 * Lock onto `optimize-css-assets-webpack-plugin` `5.0.6` to avoid `postcss` `v8`. Fixes STRWEB-19.
 * Add `loose` to `plugin-proposal-private-property-in-object`. Fixes STRWEB-21.
+* Export babel config options for consumption by other modules. Refs STRWEB-22, STRIPES-742.
 
 ## [1.3.0](https://github.com/folio-org/stripes-webpack/tree/v1.3.0) (2021-06-08)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v1.2.0...v1.3.0)

--- a/index.js
+++ b/index.js
@@ -1,0 +1,4 @@
+const babelOptions = require('./webpack/babel-options');
+module.exports = {
+  babelOptions,
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-webpack",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "The webpack config for stripes",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/webpack/babel-loader-rule.js
+++ b/webpack/babel-loader-rule.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const babelOptions = require('./babel-options');
 
 // a space delimited list of strings (typically namespaces) to use in addition
 // to "@folio" to determine if something needs Stripes-flavoured transpilation
@@ -37,35 +38,8 @@ function babelLoaderTest(fileName) {
 module.exports = {
   test: babelLoaderTest,
   loader: 'babel-loader',
-  options: {
+  options = {
     cacheDirectory: true,
-    presets: [
-      ['@babel/preset-env', { targets: '> 0.25%, not dead' }],
-      ['@babel/preset-flow', { all: true }],
-      ['@babel/preset-react', {
-        "runtime": "automatic"
-      }],
-      ['@babel/preset-typescript'],
-    ],
-    plugins: [
-      ['@babel/plugin-proposal-decorators', { 'legacy': true }],
-      // when building a platform directly, i.e. outside a workspace,
-      // babel complains loudly and repeatedly that when these modules are enabled:
-      // * @babel/plugin-proposal-class-properties,
-      // * @babel/plugin-proposal-private-methods and
-      // * @babel/plugin-proposal-private-property-in-object
-      // the "loose" option must be the same for all three.
-      // but @babel/preset-env sets it to false for ...private-methods.
-      // overriding it here silences the complaint. STRWEB-12
-      ['@babel/plugin-proposal-class-properties', { 'loose': true }],
-      ['@babel/plugin-proposal-private-methods', { 'loose': true }],
-      ['@babel/plugin-proposal-private-property-in-object', { 'loose': true }],
-      '@babel/plugin-proposal-export-namespace-from',
-      '@babel/plugin-proposal-function-sent',
-      '@babel/plugin-proposal-numeric-separator',
-      '@babel/plugin-proposal-throw-expressions',
-      '@babel/plugin-syntax-import-meta',
-      [require.resolve('react-hot-loader/babel')],
-    ]
+    ...babelOptions,
   },
 };

--- a/webpack/babel-loader-rule.js
+++ b/webpack/babel-loader-rule.js
@@ -38,7 +38,7 @@ function babelLoaderTest(fileName) {
 module.exports = {
   test: babelLoaderTest,
   loader: 'babel-loader',
-  options = {
+  options: {
     cacheDirectory: true,
     ...babelOptions,
   },

--- a/webpack/babel-options.js
+++ b/webpack/babel-options.js
@@ -1,0 +1,30 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', { targets: '> 0.25%, not dead' }],
+    ['@babel/preset-flow', { all: true }],
+    ['@babel/preset-react', {
+      "runtime": "automatic"
+    }],
+    ['@babel/preset-typescript'],
+  ],
+  plugins: [
+    ['@babel/plugin-proposal-decorators', { 'legacy': true }],
+    // when building a platform directly, i.e. outside a workspace,
+    // babel complains loudly and repeatedly that when these modules are enabled:
+    // * @babel/plugin-proposal-class-properties,
+    // * @babel/plugin-proposal-private-methods and
+    // * @babel/plugin-proposal-private-property-in-object
+    // the "loose" option must be the same for all three.
+    // but @babel/preset-env sets it to false for ...private-methods.
+    // overriding it here silences the complaint. STRWEB-12
+    ['@babel/plugin-proposal-class-properties', { 'loose': true }],
+    ['@babel/plugin-proposal-private-methods', { 'loose': true }],
+    ['@babel/plugin-proposal-private-property-in-object', { 'loose': true }],
+    '@babel/plugin-proposal-export-namespace-from',
+    '@babel/plugin-proposal-function-sent',
+    '@babel/plugin-proposal-numeric-separator',
+    '@babel/plugin-proposal-throw-expressions',
+    '@babel/plugin-syntax-import-meta',
+    [require.resolve('react-hot-loader/babel')],
+  ],
+};


### PR DESCRIPTION
Export the babel config options so they may consumed by other modules
that need access to the config either to correctly handle linting
(STRIPES-742) or Jest/RTL testing (STRIPES-757).

Refs [STRWEB-22](https://issues.folio.org/browse/STRWEB-22)