### PR TITLE
STRWEB-20: Setup babel-plugin-lodash correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Lock onto `optimize-css-assets-webpack-plugin` `5.0.6` to avoid `postcss` `v8`. Fixes STRWEB-19.
 * Add `loose` to `plugin-proposal-private-property-in-object`. Fixes STRWEB-21.
 * Export babel config options for consumption by other modules. Refs STRWEB-22, STRIPES-742, STRIPES-757.
+* Setup babel-plugin-lodash correctly. Fixes STRWEB-20.
 
 ## [1.3.0](https://github.com/folio-org/stripes-webpack/tree/v1.3.0) (2021-06-08)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v1.2.0...v1.3.0)

--- a/webpack/babel-options.js
+++ b/webpack/babel-options.js
@@ -8,6 +8,7 @@ module.exports = {
     ['@babel/preset-typescript'],
   ],
   plugins: [
+    ['lodash'],
     ['@babel/plugin-proposal-decorators', { 'legacy': true }],
     // when building a platform directly, i.e. outside a workspace,
     // babel complains loudly and repeatedly that when these modules are enabled:


### PR DESCRIPTION
This PR turns on `babel-plugin-lodash`.

Here are some stats from `platform-complete` before and after the change.

Before:
![before](https://user-images.githubusercontent.com/63545/130585423-a018cd03-af8f-4d51-acfe-ce41cb0aeee3.png)

After:
![after](https://user-images.githubusercontent.com/63545/130585461-7835d6b1-6cfb-4215-82f3-b91263bf255a.png)
