### PR TITLE
STRWEB-25 permit react 17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Setup babel-plugin-lodash correctly. Fixes STRWEB-20.
 * Upgrade PostCSS depenency stack. Refs STRWEB-23
 * Conditionally inject shared style aliases based on development context. Refs STRWEB-23, STCLI-183
+* Include `react` `v17` in the peer-deps, along with `v16`. Refs STRWEB-25.
 
 ## [1.3.0](https://github.com/folio-org/stripes-webpack/tree/v1.3.0) (2021-06-08)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v1.2.0...v1.3.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for stripes-webpack
 
-## 1.4.0 IN PROGRESS
+## 2.0.0 IN PROGRESS
 
 * Lock onto `optimize-css-assets-webpack-plugin` `5.0.6` to avoid `postcss` `v8`. Fixes STRWEB-19.
 * Add `loose` to `plugin-proposal-private-property-in-object`. Fixes STRWEB-21.
@@ -8,7 +8,7 @@
 * Setup babel-plugin-lodash correctly. Fixes STRWEB-20.
 * Upgrade PostCSS depenency stack. Refs STRWEB-23
 * Conditionally inject shared style aliases based on development context. Refs STRWEB-23, STCLI-183
-* Include `react` `v17` in the peer-deps, along with `v16`. Refs STRWEB-25.
+* Include `react` `v17` in the peer-deps. Refs STRWEB-25.
 
 ## [1.3.0](https://github.com/folio-org/stripes-webpack/tree/v1.3.0) (2021-06-08)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v1.2.0...v1.3.0)

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@babel/preset-typescript": "^7.7.7",
     "@babel/register": "^7.0.0",
     "@bigtest/mirage": "^0.0.1",
-    "@hot-loader/react-dom": "^16.8.6",
+    "@hot-loader/react-dom": "^17.0.1",
     "add-asset-html-webpack-plugin": "^3.1.3",
     "autoprefixer": "^9.1.1",
     "babel-loader": "^8.0.0",
@@ -86,7 +86,7 @@
     "sinon-chai": "^3.3.0"
   },
   "peerDependencies": {
-    "react": "^16.14.0",
-    "react-dom": "^16.14.0"
+    "react": "^16.14.0 || ^17.0.2",
+    "react-dom": "^16.14.0 || ^17.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-webpack",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "The webpack config for stripes",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -86,7 +86,7 @@
     "sinon-chai": "^3.3.0"
   },
   "peerDependencies": {
-    "react": "^16.14.0 || ^17.0.2",
-    "react-dom": "^16.14.0 || ^17.0.2"
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   }
 }


### PR DESCRIPTION
Allow react 16 and 17 as peer-dependencies in order to avoid build
warnings.

Refs [STRWEB-25](https://issues.folio.org/browse/STRWEB-25), [UXPROD-3264](https://issues.folio.org/browse/UXPROD-3264)