### PR TITLE
Supply webpack aliases to serve

### DIFF
--- a/webpack.config.cli.dev.shared.styles.js
+++ b/webpack.config.cli.dev.shared.styles.js
@@ -7,8 +7,6 @@ module.exports = (config, context) => {
     // aliasing the interactionStyles.css and variables.css as resolving those can be problematic in a workspace.
     config.resolve.alias = {
       ...config.resolve.alias,
-      // ".@folio/stripes-components/lib/Selection/Selection.css": getSharedStyles("lib/Selection/Selection.css"),
-      // ".@folio/stripes-components/lib/MultiSelection/MultiSelect.css": getSharedStyles("lib/MultiSelection/MultiSelect.css"),
       "./@folio/stripes-components/lib/sharedStyles/interactionStyles.css" : getSharedStyles("lib/sharedStyles/interactionStyles"),
       "./@folio/stripes-components/lib/variables.css": getSharedStyles("lib/variables"),
       "stcom-interactionStyles": getSharedStyles("lib/sharedStyles/interactionStyles"),

--- a/webpack.config.cli.dev.shared.styles.js
+++ b/webpack.config.cli.dev.shared.styles.js
@@ -7,6 +7,8 @@ module.exports = (config, context) => {
     // aliasing the interactionStyles.css and variables.css as resolving those can be problematic in a workspace.
     config.resolve.alias = {
       ...config.resolve.alias,
+      // ".@folio/stripes-components/lib/Selection/Selection.css": getSharedStyles("lib/Selection/Selection.css"),
+      // ".@folio/stripes-components/lib/MultiSelection/MultiSelect.css": getSharedStyles("lib/MultiSelection/MultiSelect.css"),
       "./@folio/stripes-components/lib/sharedStyles/interactionStyles.css" : getSharedStyles("lib/sharedStyles/interactionStyles"),
       "./@folio/stripes-components/lib/variables.css": getSharedStyles("lib/variables"),
       "stcom-interactionStyles": getSharedStyles("lib/sharedStyles/interactionStyles"),

--- a/webpack/serve.js
+++ b/webpack/serve.js
@@ -22,6 +22,11 @@ module.exports = function serve(stripesConfig, options) {
     logger.log('starting serve...');
     const app = express();
     let config = require('../webpack.config.cli.dev'); // eslint-disable-line global-require
+    let developmentConfig = require('../webpack.config.cli.dev.shared.styles');
+
+    if (process.env.NODE_ENV === 'development') {
+      config = developmentConfig(config, {});
+    }
 
     config.plugins.push(new StripesWebpackPlugin({ stripesConfig }));
 


### PR DESCRIPTION
For 'development' environment, the webpack aliases can be missing if running within a workspace. This code adds those aliases to development mode.

other imports within modules (for non-shared styles,, component-specific styles) should try using `~` before the import, e.g.
```
composes: multiSelectOptionList from '@folio/stripes-components/lib/MultiSelection/MultiSelect.css';
```
should become 
```
composes: multiSelectOptionList from '~@folio/stripes-components/lib/MultiSelection/MultiSelect.css';
```

As per direction from our version of CSS-loader here: https://github.com/webpack-contrib/css-loader/tree/v4.3.0#import
