### PR TITLE
STRWEB-4 Add crypto-browserify depenency to polyfill crypto in axe test runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "commander": "^2.9.0",
     "connect-history-api-fallback": "^1.3.0",
     "core-js": "^3.6.1",
+    "crypto-browserify": "^3.12.0",
     "css-loader": "^6.4.0",
     "css-minimizer-webpack-plugin": "3.1.1",
     "csv-loader": "^3.0.3",

--- a/webpack.config.cli.dev.js
+++ b/webpack.config.cli.dev.js
@@ -107,6 +107,7 @@ devConfig.plugins.push(
 
 // add resolutions for node utilities required for test suites.
 devConfig.resolve.fallback = {
+  "crypto": require.resolve('crypto-browserify'),
   "stream": require.resolve('stream-browserify'),
   "util": require.resolve('util-ex'),
 };


### PR DESCRIPTION
[`webpack` `v5` removed many polyfills that were present in `v4`](https://webpack.js.org/blog/2020-10-10-webpack-5-release/#automatic-nodejs-polyfills-removed). This PR restores one of them, resolving this error message:
```
message: "Module not found: Error: Can't resolve 'crypto' in '/Users/zburke/projects/folio-org/stripes-components/node_modules/axe-core'\n"
```
