### PR TITLE
STRWEB-30: Turn on lazy loading for ui modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-webpack",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "The webpack config for stripes",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -14,11 +14,16 @@ const typescriptLoaderRule = require('./webpack/typescript-loader-rule');
 const specificReact = generateStripesAlias('react');
 
 module.exports = {
-  entry: [
-    '@folio/stripes-components/lib/global.css',
-    '@folio/stripes-core/src/index',
-    //path.join(__dirname, 'src', 'index'),
-  ],
+  entry: {
+    css: '@folio/stripes-components/lib/global.css',
+    stripesConfig: {
+      import: 'stripes-config.js'
+    },
+    index: {
+      dependOn: 'stripesConfig',
+      import: '@folio/stripes-core/src/index'
+    },
+  },
   resolve: {
     alias: {
       'react': specificReact,

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -13,6 +13,30 @@ const typescriptLoaderRule = require('./webpack/typescript-loader-rule');
 // stripes-core (__dirname) before falling back to the platform or simply react
 const specificReact = generateStripesAlias('react');
 
+// A few details about stripes-config and entry
+//
+// Stripes config in Folio is currently assembled via webpack virtual module (https://github.com/sysgears/webpack-virtual-modules).
+// This plugin is a clever way to generate virtual (in memory) files dynamically.
+// What it means in practice is that it fools webpack to think that it deals with a real module/file
+// (like any other real module under node_modules) but in reality that file doesn't really exist.
+// Stripes config is "saved" under node_modules/stripes-config.js and it happens here:
+
+// https://github.com/folio-org/stripes-webpack/blob/master/webpack/stripes-config-plugin.js#L87
+
+// Since webpack treats it as a real module we can use it as an entry path and extract it into a separate
+// chunk with (when we bundle for production env):
+
+// entry: {
+//   stripesConfig: {
+//     import: 'stripes-config.js'
+//   },
+// }
+
+// The important part here is that the name used by the virtual module in https://github.com/folio-org/stripes-webpack/blob/master/webpack/stripes-config-plugin.js#L87
+// has to match with the name under import (in our case stripes-config.js).
+// Since we are now on the webpack 5 we can make use of dependOn (https://webpack.js.org/configuration/entry-context/#dependencies)
+// in order to create a dependency between stripes config and other chunks:
+
 module.exports = {
   entry: {
     css: '@folio/stripes-components/lib/global.css',

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -21,7 +21,7 @@ const specificReact = generateStripesAlias('react');
 // (like any other real module under node_modules) but in reality that file doesn't really exist.
 // Stripes config is "saved" under node_modules/stripes-config.js and it happens here:
 
-// https://github.com/folio-org/stripes-webpack/blob/master/webpack/stripes-config-plugin.js#L87
+// https://github.com/folio-org/stripes-webpack/blob/730ef33ee5a7799521408453b6e75653a21c3bfd/webpack/stripes-config-plugin.js#L87
 
 // Since webpack treats it as a real module we can use it as an entry path and extract it into a separate
 // chunk with (when we bundle for production env):

--- a/webpack.config.cli.dev.js
+++ b/webpack.config.cli.dev.js
@@ -48,8 +48,11 @@ const devConfig = Object.assign({}, base, cli, {
 
 // Override filename to remove the hash in development due to memory issues (STCOR-296)
 devConfig.output.filename = 'bundle.js';
-
-devConfig.entry.unshift('webpack-hot-middleware/client');
+devConfig.entry = [
+  'webpack-hot-middleware/client',
+  '@folio/stripes-components/lib/global.css',
+  '@folio/stripes-core/src/index',
+];
 
 devConfig.plugins = devConfig.plugins.concat([
   new webpack.HotModuleReplacementPlugin(),

--- a/webpack.config.cli.js
+++ b/webpack.config.cli.js
@@ -6,8 +6,8 @@ const path = require('path');
 module.exports = {
   output: {
     path: path.join(__dirname, 'dist'),
-    filename: 'bundle.[contenthash].js',
-    chunkFilename: 'chunk.[chunkhash].js',
+    filename: 'bundle.[name][contenthash].js',
+    chunkFilename: 'chunk.[name][chunkhash].js',
     publicPath: '/',
   },
 };

--- a/webpack/stripes-module-parser.js
+++ b/webpack/stripes-module-parser.js
@@ -107,8 +107,6 @@ class StripesModuleParser {
   }
 
   // Validates and parses a module's stripes data
-  // One critical aspect of this operation is value of getModule, which is the entry point into each app
-  // This will be modified to a webpack-compatible dynamic import when we implement code-splitting.
   parseStripesConfig(moduleName, packageJson) {
     const { stripes, description, version } = packageJson;
     const stripeConfig = _.omit(Object.assign({}, stripes, this.overrideConfig, {

--- a/webpack/stripes-module-parser.js
+++ b/webpack/stripes-module-parser.js
@@ -111,10 +111,11 @@ class StripesModuleParser {
   // This will be modified to a webpack-compatible dynamic import when we implement code-splitting.
   parseStripesConfig(moduleName, packageJson) {
     const { stripes, description, version } = packageJson;
-
     const stripeConfig = _.omit(Object.assign({}, stripes, this.overrideConfig, {
       module: moduleName,
-      getModule: new Function([], `return require('${moduleName}').default;`), // eslint-disable-line no-new-func
+      getModule: new Function([], `
+        const { lazy } = require('react');
+        return lazy(() => import(/* webpackChunkName: "${moduleName}" */ '${moduleName}'));`),
       description,
       version,
     }), TOP_LEVEL_ONLY);


### PR DESCRIPTION
https://issues.folio.org/browse/STRWEB-30

This PR does two things:

1. Introduces lazy loading for ui modules which allows for shrinking the size of the main js bundle (about 5 times).

Each UI module will end up in its own chunk:

![ui-chunks](https://user-images.githubusercontent.com/63545/146829716-33bfdb66-c1a4-4d47-aa69-a9c8035f96c4.png)

This is a breaking change as additional changes will be required in stripes-core in order to support lazy loading:

https://github.com/folio-org/stripes-core/pull/1147

2. Splits out stripes-config into a separate chunk via `dependOn` option.

## A few details about stripes-config and entries

Stripes config in Folio is currently assembled via webpack virtual module (https://github.com/sysgears/webpack-virtual-modules). This plugin is a clever way to generate virtual (in memory) files dynamically. What it means in practice is that it fools webpack to think that it deals with a real module/file (like any other real module under node_modules) but in reality that file doesn't really exist.

Stripes config is "saved" under `node_modules/stripes-config.js` and it happens here:

https://github.com/folio-org/stripes-webpack/blob/master/webpack/stripes-config-plugin.js#L87

Since webpack treats it as a real module we can use it as an entry path and extract it into a separate chunk (when we bundle for production env) with:

````js
entry: {
  stripesConfig: {
    import: 'stripes-config.js'
  },
}
````

The important part here is that the name used by the virtual module in https://github.com/folio-org/stripes-webpack/blob/730ef33ee5a7799521408453b6e75653a21c3bfd/webpack/stripes-config-plugin.js#L87 has to match with the name under `import` (in our case `stripes-config.js`).

Since we are now on the webpack 5 we can make use of `dependOn` (https://webpack.js.org/configuration/entry-context/#dependencies) in order to create a dependency between stripes config and other chunks:

````js
entry: {
  stripesConfig: {
    import: 'stripes-config.js'
  },
  index: {
    dependOn: 'stripesConfig',
    import: '@folio/stripes-core/src/index'
  },
},
````

