### PR TITLE
Alias browser mocha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Update webpack to v5. Refs STRWEB-4.
 * Dependency cleanup. Refs STRWEB-31.
+* Alias Mocha to reduce console noise. Refs STRWEB-32.
 
 ## [2.0.0](https://github.com/folio-org/stripes-webpack/tree/v2.0.0) (2021-09-24)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v1.3.0...v2.0.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-webpack",
-  "version": "3.0.0",
+  "version": "3.0.2",
   "description": "The webpack config for stripes",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/webpack.config.cli.dev.js
+++ b/webpack.config.cli.dev.js
@@ -57,7 +57,7 @@ devConfig.plugins = devConfig.plugins.concat([
 // This alias avoids a console warning for react-dom patch
 devConfig.resolve.alias['react-dom'] = '@hot-loader/react-dom';
 devConfig.resolve.alias.process = 'process/browser.js';
-
+devConfig.resolve.alias['mocha'] = 'mocha/mocha-es2018.js';
 devConfig.module.rules.push({
   test: /\.css$/,
   use: [


### PR DESCRIPTION
Reduces a bit of the noise when spinning up test suites due to mocha's node-functional version being its primary export....

This creates an alias for the 'mocha' import to its browser version (polyfills some of the node `'process` API)
based on the final comment here: https://github.com/mochajs/mocha/issues/2448#issuecomment-928822632

This reduces the console noise in the testing terminal, removing one or more occurrences of:
```
 {
    moduleIdentifier: '/home/runner/work/stripes-components/stripes-components/node_modules/mocha/lib/mocha.js',
    moduleName: './node_modules/mocha/lib/mocha.js',
    loc: '342:19-40',
    message: 'Critical dependency: the request of a dependency is an expression',
    moduleId: './node_modules/mocha/lib/mocha.js',
    moduleTrace: [ [Object], [Object], [Object], [Object] ],
    details: '    at CommonJsRequireContextDependency.getWarnings (/home/runner/work/stripes-components/stripes-components/node_modules/webpack/lib/dependencies/ContextDependency.js:91:18)\n' +
      '    at Compilation.reportDependencyErrorsAndWarnings (/home/runner/work/stripes-components/stripes-components/node_modules/webpack/lib/Compilation.js:3127:24)\n' +
      '    at /home/runner/work/stripes-components/stripes-components/node_modules/webpack/lib/Compilation.js:2724:28\n' +
      '    at eval (eval at create (/home/runner/work/stripes-components/stripes-components/node_modules/webpack/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:27:1)\n' +
      '    at /home/runner/work/stripes-components/stripes-components/node_modules/webpack/lib/FlagDependencyExportsPlugin.js:385:11\n' +
      '    at /home/runner/work/stripes-components/stripes-components/node_modules/neo-async/async.js:2830:7\n' +
      '    at Object.each (/home/runner/work/stripes-components/stripes-components/node_modules/neo-async/async.js:2850:39)\n' +
      '    at /home/runner/work/stripes-components/stripes-components/node_modules/webpack/lib/FlagDependencyExportsPlugin.js:361:18\n' +
      '    at /home/runner/work/stripes-components/stripes-components/node_modules/neo-async/async.js:2830:7\n' +
      '    at done (/home/runner/work/stripes-components/stripes-components/node_modules/neo-async/async.js:2865:11)',
    stack: 'ModuleDependencyWarning: Critical dependency: the request of a dependency is an expression\n' +
      '    at Compilation.reportDependencyErrorsAndWarnings (/home/runner/work/stripes-components/stripes-components/node_modules/webpack/lib/Compilation.js:3132:23)\n' +
      '    at /home/runner/work/stripes-components/stripes-components/node_modules/webpack/lib/Compilation.js:2724:28\n' +
      '    at eval (eval at create (/home/runner/work/stripes-components/stripes-components/node_modules/webpack/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:27:1)\n' +
      '    at /home/runner/work/stripes-components/stripes-components/node_modules/webpack/lib/FlagDependencyExportsPlugin.js:385:11\n' +
      '    at /home/runner/work/stripes-components/stripes-components/node_modules/neo-async/async.js:2830:7\n' +
      '    at Object.each (/home/runner/work/stripes-components/stripes-components/node_modules/neo-async/async.js:2850:39)\n' +
      '    at /home/runner/work/stripes-components/stripes-components/node_modules/webpack/lib/FlagDependencyExportsPlugin.js:361:18\n' +
      '    at /home/runner/work/stripes-components/stripes-components/node_modules/neo-async/async.js:2830:7\n' +
      '    at done (/home/runner/work/stripes-components/stripes-components/node_modules/neo-async/async.js:2865:11)\n' +
      '    at /home/runner/work/stripes-components/stripes-components/node_modules/neo-async/async.js:2818:7'
  } ....
```