### PR TITLE
STRWEB-34 Fix source maps are not generated in dev build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Update webpack to v5. Refs STRWEB-4.
 * Dependency cleanup. Refs STRWEB-31.
 * Alias Mocha to reduce console noise. Refs STRWEB-32.
+* Fix source maps. Fixes STRWEB-34.
 
 ## [2.0.0](https://github.com/folio-org/stripes-webpack/tree/v2.0.0) (2021-09-24)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v1.3.0...v2.0.0)

--- a/webpack.config.cli.dev.js
+++ b/webpack.config.cli.dev.js
@@ -33,12 +33,12 @@ const useBrowserMocha = () => {
 };
 
 const devConfig = Object.assign({}, base, cli, {
-  devtool: 'eval-cheap-source-map',
+  devtool: 'inline-source-map',
   mode: 'development',
   cache: {
     type: 'filesystem',
+    name: 'FOLIOCache',
   },
-  mode: 'development',
   target: 'web',
   infrastructureLogging: {
     appendOnly: true,


### PR DESCRIPTION
## Description
Fixed source maps not generating.
The issue was caused by changes in two config properties: `devtool` and `cache`
Through trial and error I found that the only `devtool` value that generated correct source maps was `inline-source-map`.
Still, source maps weren't generating without `cache.name` property. It should have a default value that should work (https://webpack.js.org/configuration/cache/#cachename), but for some reason it doesn't. 

## Issues
[STRWEB-34](https://issues.folio.org/browse/STRWEB-34)