### PR TITLE
STRWEB-35 avoid buggy third-party-dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-webpack
 
+## 3.0.3 IN PROGRESS
+
+* Avoid broken `@cerner/duplicate-package-checker-webpack-plugin` `v2.2.0` which introduces new node version restrictions. Refs STRWEB-35.
+
 ## [3.0.2](https://github.com/folio-org/stripes-webpack/tree/v3.0.2) (2022-02-08)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v2.0.0...v3.0.2)
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@babel/preset-typescript": "^7.7.7",
     "@babel/register": "^7.0.0",
     "@bigtest/mirage": "^0.0.1",
-    "@cerner/duplicate-package-checker-webpack-plugin": "^2.1.0",
+    "@cerner/duplicate-package-checker-webpack-plugin": "~2.1.0",
     "@hot-loader/react-dom": "^17.0.1",
     "add-asset-html-webpack-plugin": "^3.2.0",
     "autoprefixer": "^9.1.1",


### PR DESCRIPTION
`@cerner/duplicate-package-checker-webpack-plugin` `2.2.0` introduced
new node engine restrictions without incrementing their major version.
Whoops. I suspect they didn't realize that their previous `>=10 || <13`
configuration short-circuited to `>=10`. Sigh.

Details: https://github.com/cerner/terra-toolkit/issues/730

Refs [STRWEB-35](https://issues.folio.org/browse/STRWEB-35)