### PR TITLE
STRWEB-27: Do not include react-refresh babel plugin  in prod env

### DIFF
--- a/webpack/babel-options.js
+++ b/webpack/babel-options.js
@@ -1,3 +1,6 @@
+
+const isDevelopment = process.env.NODE_ENV !== 'production';
+
 module.exports = {
   presets: [
     ['@babel/preset-env', { targets: '> 0.25%, not dead' }],
@@ -26,6 +29,6 @@ module.exports = {
     '@babel/plugin-proposal-numeric-separator',
     '@babel/plugin-proposal-throw-expressions',
     '@babel/plugin-syntax-import-meta',
-    [require.resolve('react-refresh/babel')],
+    [isDevelopment && require.resolve('react-refresh/babel')].filter(Boolean),
   ],
 };


### PR DESCRIPTION
We should not include `react-refresh/babel` babel transform in production env.