### PR TITLE
STRWEB-27: Include HMR plugins only when in development env

### DIFF
--- a/webpack.config.cli.dev.js
+++ b/webpack.config.cli.dev.js
@@ -14,10 +14,10 @@ const postCssColorFunction = require('postcss-color-function');
 const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
 
 const { generateStripesAlias, tryResolve } = require('./webpack/module-paths');
+const utils = require('./webpack/utils');
 
 const base = require('./webpack.config.base');
 const cli = require('./webpack.config.cli');
-
 
 const locateCssVariables = () => {
   const variables = 'lib/variables.css';
@@ -54,12 +54,18 @@ devConfig.output.filename = 'bundle.js';
 devConfig.entry.unshift('webpack-hot-middleware/client');
 
 devConfig.plugins = devConfig.plugins.concat([
-  new webpack.HotModuleReplacementPlugin(),
-  new ReactRefreshWebpackPlugin(),
   new webpack.ProvidePlugin({
     process: 'process/browser.js',
   }),
 ]);
+
+// include HMR plugins only when in development
+if (utils.isDevelopment) {
+  devConfig.plugins = devConfig.plugins.concat([
+    new webpack.HotModuleReplacementPlugin(),
+    new ReactRefreshWebpackPlugin()
+  ]);
+}
 
 // This alias avoids a console warning for react-dom patch
 devConfig.resolve.alias.process = 'process/browser.js';

--- a/webpack/babel-options.js
+++ b/webpack/babel-options.js
@@ -1,5 +1,4 @@
-
-const isDevelopment = process.env.NODE_ENV !== 'production';
+const utils = require('./utils');
 
 module.exports = {
   presets: [
@@ -29,6 +28,6 @@ module.exports = {
     '@babel/plugin-proposal-numeric-separator',
     '@babel/plugin-proposal-throw-expressions',
     '@babel/plugin-syntax-import-meta',
-    isDevelopment && require.resolve('react-refresh/babel'),
+    utils.isDevelopment && require.resolve('react-refresh/babel'),
   ].filter(Boolean),
 };

--- a/webpack/utils.js
+++ b/webpack/utils.js
@@ -1,0 +1,3 @@
+module.exports = {
+  isDevelopment: process.env.NODE_ENV === 'development'
+};


### PR DESCRIPTION
Include HMR plugins only when in development env. This was missed in the original PR.

https://issues.folio.org/browse/STRWEB-27

