### PR TITLE
STRWEB-43 Lock postcss-custom-properties to 12.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "postcss-calc": "^8.0.0",
     "postcss-color-function": "folio-org/postcss-color-function",
     "postcss-custom-media": "^8.0.0",
-    "postcss-custom-properties": "^12.0.0",
+    "postcss-custom-properties": "12.1.4",
     "postcss-import": "^14.0.2",
     "postcss-loader": "^6.2.0",
     "postcss-media-minmax": "^5.0.0",


### PR DESCRIPTION
12.1.5 throwing a great deal of deprecation warnings during builds. The maintainers are seeking feedback about their `importFrom` properties. I suppose that's one way to do it.

This quiets the warnings of 
```
{
    moduleIdentifier: '/home/runner/work/stripes-components/stripes-components/node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[7].use[1]!/home/runner/work/stripes-components/stripes-components/node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[7].use[2]!/home/runner/work/stripes-components/stripes-components/lib/global.css',
    moduleName: './node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[7].use[1]!./node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[7].use[2]!./lib/global.css',
    message: 'Module Warning (from ./node_modules/postcss-loader/dist/cjs.js):\n' +
      'Warning\n' +
      '\n' +
      '(1:1) postcss-custom-properties: "importFrom" and "exportTo" will be removed in a future version of postcss-custom-properties.\n' +
      'We are looking for insights and anecdotes on how these features are used so that we can design the best alternative.\n' +
      'Please let us know if our proposal will work for you.\n' +
      'Visit the discussion on github for more details. https://github.com/csstools/postcss-plugins/discussions/192',
    moduleId: './node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[7].use[1]!./node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[7].use[2]!./lib/global.css',
    moduleTrace: [ [Object], [Object], [Object], [Object], [Object] ],
    details: undefined,
    stack: 'ModuleWarning: Module Warning (from ./node_modules/postcss-loader/dist/cjs.js):\n' +
      'Warning\n' +
      '\n' +
      '(1:1) postcss-custom-properties: "importFrom" and "exportTo" will be removed in a future version of postcss-custom-properties.\n' +
      'We are looking for insights and anecdotes on how these features are used so that we can design the best alternative.\n' +
      'Please let us know if our proposal will work for you.\n' +
      'Visit the discussion on github for more details. [https://github.com/csstools/postcss-plugins/discussions/192\n](https://github.com/csstools/postcss-plugins/discussions/192/n)' +
      '    at Object.emitWarning (/home/runner/work/stripes-components/stripes-components/node_modules/webpack/lib/NormalModule.js:598:6)\n' +
      '    at Object.loader (/home/runner/work/stripes-components/stripes-components/node_modules/postcss-loader/dist/index.js:149:10)'
  },
```
and
```
<w> [webpack.cache.PackFileCacheStrategy] Skipped not serializable cache item 'Compilation/modules|/home/runner/work/stripes-components/stripes-components/node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[7].use[1]!/home/runner/work/stripes-components/stripes-components/node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[7].use[2]!/home/runner/work/stripes-components/stripes-components/lib/Icon/DotSpinner.css': No serializer registered for Warning
```
present in build logs.

We'll analyze using future releases of this plugin in [STCOM-957](https://issues.folio.org/browse/STCOM-957) and [STRWEB-43](https://issues.folio.org/browse/STRWEB-43)