### PR TITLE
STRWEB-46 use compatible autoprefixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.1.0 IN PROGRESS
 
 * Migrate from react-hot-loader to react-refresh. Refs STRWEB-27.
+* `autoprefixer` and `postcss` versions are now compatible. Refs STRWEB-46.
 
 ## [3.0.3](https://github.com/folio-org/stripes-webpack/tree/v3.0.3) (2022-02-10)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v3.0.2...v3.0.3)

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@cerner/duplicate-package-checker-webpack-plugin": "~2.1.0",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.4",
     "add-asset-html-webpack-plugin": "^3.2.0",
-    "autoprefixer": "^9.1.1",
+    "autoprefixer": "^10.4.2",
     "babel-loader": "^8.0.0",
     "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-remove-jsx-attributes": "^0.0.2",


### PR DESCRIPTION
It looks like we missed an upgrade to `autoprefixer` `v10`when we did the
`webpack` `5` and `postcss` `8` work under STRWEB-4. `v9` contains a
direct dependency on `postcss` `7`; `v10` contains a peer dependency on
`v8`. We're on `v8` now, so we want everything to be compatible with
that.

Refs [STRWEB-46](https://issues.folio.org/browse/STRWEB-46), [STRWEB-4](https://issues.folio.org/browse/STRWEB-4), [STCOM-963](https://issues.folio.org/browse/STCOM-963)