### PR TITLE
STRWEB-28 use current add-asset-html-webpack-plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.1.0 IN PROGRESS
 
 * Migrate from react-hot-loader to react-refresh. Refs STRWEB-27.
+* Migrate to current `add-asset-html-plugin` to avoid CVE-2020-28469. Refs STRWEB-28.
 
 ## [3.0.3](https://github.com/folio-org/stripes-webpack/tree/v3.0.3) (2022-02-10)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v3.0.2...v3.0.3)

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@bigtest/mirage": "^0.0.1",
     "@cerner/duplicate-package-checker-webpack-plugin": "~2.1.0",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.4",
-    "add-asset-html-webpack-plugin": "^3.2.0",
+    "add-asset-html-webpack-plugin": "^5.0.2",
     "autoprefixer": "^9.1.1",
     "babel-loader": "^8.0.0",
     "babel-plugin-lodash": "^3.3.4",

--- a/webpack/build.js
+++ b/webpack/build.js
@@ -51,7 +51,7 @@ module.exports = function build(stripesConfig, options) {
 
         const dllPath = path.dirname(dependencyPath);
 
-        dllPaths.push({ filepath: `${dllPath}/*.js` });
+        dllPaths.push({ glob: `${dllPath}/*.js` });
       }
 
       config.plugins.push(new AddAssetHtmlPlugin(dllPaths));


### PR DESCRIPTION
Older versions of `add-asset-html-webpack-plugin` rely on older versions
of `glob-parent` (< 5.1.2) that contain a redos vulnerability,
CVE-2020-28469.

Refs [STRWEB-28](https://issues.folio.org/browse/STRWEB-28)