### PR TITLE
STRWEB-41 omit any mention of react-githubish-mentions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Migrate from react-hot-loader to react-refresh. Refs STRWEB-27.
 * `autoprefixer` and `postcss` versions are now compatible. Refs STRWEB-46.
 * Migrate to current `add-asset-html-plugin` to avoid CVE-2020-28469. Refs STRWEB-28.
+* Omit last traces of (unused) `react-githubish-mentions`. Refs STRWEB-41.
 
 ## [3.0.3](https://github.com/folio-org/stripes-webpack/tree/v3.0.3) (2022-02-10)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v3.0.2...v3.0.3)

--- a/test/webpack/babel-loader-rule.spec.js
+++ b/test/webpack/babel-loader-rule.spec.js
@@ -32,11 +32,5 @@ describe('The babel-loader-rule', function () {
       const result = this.sut(fileName);
       expect(result).to.equal(true);
     });
-
-    it('does not select excluded modules', function () {
-      const fileName = '/projects/folio/stripes-smart-components/node_modules/@folio/react-githubish-mentions/lib/MentionMenu.js';
-      const result = this.sut(fileName);
-      expect(result).to.equal(false);
-    });
   });
 });

--- a/webpack/babel-loader-rule.js
+++ b/webpack/babel-loader-rule.js
@@ -7,7 +7,6 @@ const extraTranspile = process.env.STRIPES_TRANSPILE_TOKENS ? process.env.STRIPE
 
 // These modules are already transpiled and should be excluded
 const folioScopeBlacklist = [
-  'react-githubish-mentions',
 ].map(segment => path.join('@folio', segment));
 
 // Packages on NPM are typically distributed already transpiled. For historical


### PR DESCRIPTION
This is really just a clean-up job; in fact
`@folio/react-githubish-mentions` was not even part of the initial
commit for `package.json`, indicating it must have been removed from
`stripes-core` before this repo was split off. Anyway: we had a
lingering test case that mentioned it, but it was not a great test to
begin with, amounting to, "make sure ${items} are present in ${list}",
which just meant we had `${items}` hard-coded in two places instead of
one.

Refs [STRWEB-41](https://issues.folio.org/browse/STRWEB-41)