### PR TITLE
remove @bigtest/mirage dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@babel/preset-react": "^7.9.0",
     "@babel/preset-typescript": "^7.7.7",
     "@babel/register": "^7.0.0",
-    "@bigtest/mirage": "^0.0.1",
     "@cerner/duplicate-package-checker-webpack-plugin": "~2.1.0",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.4",
     "add-asset-html-webpack-plugin": "^5.0.2",


### PR DESCRIPTION
most modules that used @bigtest/mirage migrated to miragejs earlier. In the case of stripes-webpack, I'm not sure why the dependency is present...