### PR TITLE
favicons with url-regex DoS (CVE-2020-7661)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for stripes-webpack
 
-## 3.1.0 IN PROGRESS
+## 4.0.0 IN PROGRESS
 
 * Migrate from react-hot-loader to react-refresh. Refs STRWEB-27.
 * `autoprefixer` and `postcss` versions are now compatible. Refs STRWEB-46.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * `autoprefixer` and `postcss` versions are now compatible. Refs STRWEB-46.
 * Migrate to current `add-asset-html-plugin` to avoid CVE-2020-28469. Refs STRWEB-28.
 * Omit last traces of (unused) `react-githubish-mentions`. Refs STRWEB-41.
+* Fix favicons with url-regex DoS. Refs STRWEB-50.
 
 ## [3.0.3](https://github.com/folio-org/stripes-webpack/tree/v3.0.3) (2022-02-10)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v3.0.2...v3.0.3)

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "csv-loader": "^3.0.3",
     "debug": "^4.0.1",
     "express": "^4.14.0",
-    "favicons": "^6.2.2",
+    "favicons": "^7.0.0-beta.4",
     "favicons-webpack-plugin": "^5.0.2",
     "file-loader": "^6.2.0",
     "handlebars": "^4.7.7",


### PR DESCRIPTION
- Fixes [STRWEB-50](https://issues.folio.org/browse/STRWEB-50)
- Updated `favicon` to `7.0.0-beta.4` which removes dependency on `to-ico`
- Updated CHANGELOG IN PROGRESS version to `4.0.0` to match current `package.json` version