### PR TITLE
STRWEB-52: Do not lazy load handler modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * `autoprefixer` and `postcss` versions are now compatible. Refs STRWEB-46.
 * Migrate to current `add-asset-html-plugin` to avoid CVE-2020-28469. Refs STRWEB-28.
 * Omit last traces of (unused) `react-githubish-mentions`. Refs STRWEB-41.
+* Do not lazy load handlers. Refs STRWEB-52.
 
 ## [3.0.3](https://github.com/folio-org/stripes-webpack/tree/v3.0.3) (2022-02-10)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v3.0.2...v3.0.3)

--- a/webpack/stripes-module-parser.js
+++ b/webpack/stripes-module-parser.js
@@ -101,13 +101,13 @@ class StripesModuleParser {
     return {
       name: this.nameOnly,
       actsAs,
-      config: this.config || this.parseStripesConfig(this.moduleName, actsAs, this.packageJson),
+      config: this.config || this.parseStripesConfig(this.moduleName, this.packageJson, actsAs),
       metadata: this.metadata || this.parseStripesMetadata(this.packageJson),
     };
   }
 
   // Validates and parses a module's stripes data
-  parseStripesConfig(moduleName, actsAs, packageJson) {
+  parseStripesConfig(moduleName, packageJson, actsAs = []) {
     const { stripes, description, version } = packageJson;
     const isHandler = actsAs.includes('handler');
 

--- a/webpack/stripes-module-parser.js
+++ b/webpack/stripes-module-parser.js
@@ -101,15 +101,15 @@ class StripesModuleParser {
     return {
       name: this.nameOnly,
       actsAs,
-      config: this.config || this.parseStripesConfig(this.moduleName, this.packageJson),
+      config: this.config || this.parseStripesConfig(this.moduleName, actsAs, this.packageJson),
       metadata: this.metadata || this.parseStripesMetadata(this.packageJson),
     };
   }
 
   // Validates and parses a module's stripes data
-  parseStripesConfig(moduleName, packageJson) {
+  parseStripesConfig(moduleName, actsAs, packageJson) {
     const { stripes, description, version } = packageJson;
-    const isHandler = stripes?.actsAs?.includes('handler');
+    const isHandler = actsAs.includes('handler');
 
     // Do not lazy load handlers
     // more details in https://issues.folio.org/browse/STRWEB-52


### PR DESCRIPTION
https://issues.folio.org/browse/STRWEB-52

All modules including handlers are currently lazy-loaded via `react.lazy`:

https://github.com/folio-org/stripes-webpack/pull/42/files#diff-e2d205c418f31e84d2da3758111d8d588cfac741d152c953fad9283a0f7099d1R116

Unfortunately, this doesn't work for handlers because handlers define static methods:

https://github.com/folio-org/ui-servicepoints/blob/7c55718c0c4143d6b77dc8707a0507589f50af00/src/index.js#L13
https://github.com/folio-org/ui-servicepoints/blob/7c55718c0c4143d6b77dc8707a0507589f50af00/src/index.js#L9

these methods are invoked outside of react render context:

https://github.com/folio-org/stripes-core/blob/be772d924fca97e2189e954a1c9075c629b6f645/src/components/MainNav/ProfileDropdown/ProfileDropdown.js#L93

and they are lost when a handler module is loaded via 

`lazy(() => import(...))`

This PR skips lazy-loading handler modules and uses `require('${moduleName}').default;` (this is what we had in the previous implementation).


