### PR TITLE
STRWEB-53: Do not lazy load plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Migrate to current `add-asset-html-plugin` to avoid CVE-2020-28469. Refs STRWEB-28.
 * Omit last traces of (unused) `react-githubish-mentions`. Refs STRWEB-41.
 * Do not lazy load handlers. Refs STRWEB-52.
+* Do not lazy load plugins. Refs STRWEB-53.
 
 ## [3.0.3](https://github.com/folio-org/stripes-webpack/tree/v3.0.3) (2022-02-10)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v3.0.2...v3.0.3)

--- a/webpack/stripes-module-parser.js
+++ b/webpack/stripes-module-parser.js
@@ -110,10 +110,12 @@ class StripesModuleParser {
   parseStripesConfig(moduleName, packageJson, actsAs = []) {
     const { stripes, description, version } = packageJson;
     const isHandler = actsAs.includes('handler');
+    const isPlugin = actsAs.includes('plugin');
 
-    // Do not lazy load handlers
+    // Do not lazy load handlers and plugins
     // more details in https://issues.folio.org/browse/STRWEB-52
-    const getModule = isHandler ?
+    // and https://issues.folio.org/browse/STRWEB-53
+    const getModule = (isHandler || isPlugin) ?
       new Function([], `return require('${moduleName}').default;`) :
       new Function([], `
         const { lazy } = require('react');


### PR DESCRIPTION
For some reason when plugins are lazy-loaded the position of the menu component is not correctly applied.
This is specifically visible when the plugin is embedded directly in the action menu: 

![inventory-menu](https://user-images.githubusercontent.com/63545/172873642-ac9830ef-e697-4b77-be3a-6f7efe6a6fd7.png)

https://github.com/folio-org/ui-inventory/blob/69c97906f4a8054776a551812ead87d374434b5a/src/components/InstancesList/InstancesList.js#L538-L551

At this point, I'm not sure why this happens. It could be because some CSS calculations are performed during the first render and since the lazy-loaded components are not present the calculations are not correctly applied.
The way the `create-inventory-records` plugin is used is also questionable (it is embedded in the menu where the button which opens the plugin is also part of the plugin).

This PR turns off lazy loading for plugins for now so we can move ahead with the release.

https://issues.folio.org/browse/STRWEB-53