### PR TITLE
Revert "STRWEB-53: Do not lazy load plugins (#66)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 * Migrate to current `add-asset-html-plugin` to avoid CVE-2020-28469. Refs STRWEB-28.
 * Omit last traces of (unused) `react-githubish-mentions`. Refs STRWEB-41.
 * Do not lazy load handlers. Refs STRWEB-52.
-* Do not lazy load plugins. Refs STRWEB-53.
 
 ## [3.0.3](https://github.com/folio-org/stripes-webpack/tree/v3.0.3) (2022-02-10)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v3.0.2...v3.0.3)

--- a/webpack/stripes-module-parser.js
+++ b/webpack/stripes-module-parser.js
@@ -110,12 +110,10 @@ class StripesModuleParser {
   parseStripesConfig(moduleName, packageJson, actsAs = []) {
     const { stripes, description, version } = packageJson;
     const isHandler = actsAs.includes('handler');
-    const isPlugin = actsAs.includes('plugin');
 
-    // Do not lazy load handlers and plugins
+    // Do not lazy load handlers
     // more details in https://issues.folio.org/browse/STRWEB-52
-    // and https://issues.folio.org/browse/STRWEB-53
-    const getModule = (isHandler || isPlugin) ?
+    const getModule = isHandler ?
       new Function([], `return require('${moduleName}').default;`) :
       new Function([], `
         const { lazy } = require('react');


### PR DESCRIPTION
This reverts commit 960b1a045a6a3ca46b58fe840676c390761abda7.

This is because @BogdanDenis found out why this happens by wrapping `Pluggable` in a `Suspense` in stripes-core.