### PR TITLE
STRWEB-55: Turn off lazy loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@
 * `autoprefixer` and `postcss` versions are now compatible. Refs STRWEB-46.
 * Migrate to current `add-asset-html-plugin` to avoid CVE-2020-28469. Refs STRWEB-28.
 * Omit last traces of (unused) `react-githubish-mentions`. Refs STRWEB-41.
-* Do not lazy load handlers. Refs STRWEB-52.
-* Do not lazy load plugins. Refs STRWEB-53.
+* Turn off lazy loading. Refs STRWEB-55.
 
 ## [3.0.3](https://github.com/folio-org/stripes-webpack/tree/v3.0.3) (2022-02-10)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v3.0.2...v3.0.3)

--- a/webpack/stripes-module-parser.js
+++ b/webpack/stripes-module-parser.js
@@ -101,27 +101,15 @@ class StripesModuleParser {
     return {
       name: this.nameOnly,
       actsAs,
-      config: this.config || this.parseStripesConfig(this.moduleName, this.packageJson, actsAs),
+      config: this.config || this.parseStripesConfig(this.moduleName, this.packageJson),
       metadata: this.metadata || this.parseStripesMetadata(this.packageJson),
     };
   }
 
   // Validates and parses a module's stripes data
-  parseStripesConfig(moduleName, packageJson, actsAs = []) {
+  parseStripesConfig(moduleName, packageJson) {
     const { stripes, description, version } = packageJson;
-    const isHandler = actsAs.includes('handler');
-    const isPlugin = actsAs.includes('plugin');
-
-    // Do not lazy load handlers and plugins
-    // more details in https://issues.folio.org/browse/STRWEB-52
-    // and https://issues.folio.org/browse/STRWEB-53
-    const getModule = (isHandler || isPlugin) ?
-      new Function([], `return require('${moduleName}').default;`) :
-      new Function([], `
-        const { lazy } = require('react');
-        return lazy(() => import(/* webpackChunkName: "${moduleName}" */ '${moduleName}'));`
-      );
-
+    const getModule = new Function([], `return require('${moduleName}').default;`);
     const stripeConfig = _.omit(Object.assign({}, stripes, this.overrideConfig, {
       module: moduleName,
       getModule,


### PR DESCRIPTION
We ran into multiple issues related to lazy loading in various modules:

https://issues.folio.org/browse/STCOM-1008
https://issues.folio.org/browse/STCOR-626
https://issues.folio.org/browse/STRWEB-53
https://issues.folio.org/browse/STRWEB-52

And a couple more related to `history.push`

We think most of them are fixed now but it's a lot of changes and who knows what else is not working as expected.

We decided to turn the lazy loading off for now so we can move forward with the release.

The plan is to turn it back on after the release is done so there is more time to experiment with it.

Thank you @zburke  for your voice of reason on this.