### PR TITLE
STRWEB-54: Add dom library/TSX files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-webpack
 
+## 4.1.0 IN PROGRESS
+
+* Fix TypeScript configuration a little more. Refs STRWEB-54.
+
 ## [4.0.0](https://github.com/folio-org/stripes-webpack/tree/v4.0.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v3.0.3...v4.0.0)
 

--- a/webpack/tsconfig.json
+++ b/webpack/tsconfig.json
@@ -3,9 +3,9 @@
     "noImplicitAny": true,
     "esModuleInterop": true,
     "jsx": "react",
-    "lib": ["esnext"],
+    "lib": ["esnext", "dom"],
     "module": "es6",
     "moduleResolution": "node"
   },
-  "include": ["../../**/*.ts"]
+  "include": ["../../**/*.ts", "../../**/*.tsx"]
 }


### PR DESCRIPTION
As a sequel to #68, this PR fixes some oversights in the previous PR.  It now also includes .tsx files under the `tsconfig.json`, additionally, it adds the `dom` lib, allowing the use of interfaces like `HTMLInputElement` and type-safe accessing of properties on these elements, such as `.value`.  Although this usage is relatively rare in React/JSX, it is still imperative when using refs.

Since [STRWEB-54](https://github.com/folio-org/stripes-webpack/pull/68) is still marked in review on Jira, and this PR is a very small extension of the previous changes, I thought they could be joined under the same ticket.  If this is not appropriate, let me know and I can file a new ticket for this PR.