### PR TITLE
STRWEB-57: Allow TS compilation within node_modules

### DIFF
--- a/webpack/tsconfig.json
+++ b/webpack/tsconfig.json
@@ -8,5 +8,10 @@
     "moduleResolution": "node",
     "resolveJsonModule": true
   },
-  "include": ["../../**/*.ts", "../../**/*.tsx"]
+  "include": [
+    "../../**/*.ts",
+    "../../**/*.tsx",
+    "node_modules/@folio/**/*.ts",
+    "node_modules/@folio/**/*.tsx"
+  ]
 }

--- a/webpack/typescript-loader-rule.js
+++ b/webpack/typescript-loader-rule.js
@@ -21,6 +21,7 @@ module.exports = {
     loader: 'ts-loader',
     options: {
       configFile: path.join(__dirname, 'tsconfig.json'),
+      allowTsInNodeModules: true,
     }
   }],
 };


### PR DESCRIPTION
# [Jira](https://issues.folio.org/projects/STRWEB/issues/STRWEB-57)

`ts-loader` will not, by default, compile TS found within `node_modules`.  However, when platforms are built, module code is within `node_modules`, therefore, `ts-loader` should be permitted to compile TS from within `node_modules/@folio/...`.