### PR TITLE
STRWEB-60 exclude TS test files from the build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-webpack
 
+## 4.1.1 IN PROGRESS
+
+* Filter out test files from TS repos when building. Refs STRWEB-60.
+
 ## [4.1.0](https://github.com/folio-org/stripes-webpack/tree/v4.1.0) (2022-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v4.0.0...v4.1.0)
 

--- a/webpack/tsconfig.json
+++ b/webpack/tsconfig.json
@@ -13,5 +13,11 @@
     "../../**/*.tsx",
     "node_modules/@folio/**/*.ts",
     "node_modules/@folio/**/*.tsx"
+  ],
+  "exclude": [
+    "../../**/*.test.ts",
+    "../../**/*.test.tsx",
+    "node_modules/@folio/**/*.test.ts",
+    "node_modules/@folio/**/*.test.tsx"
   ]
 }

--- a/webpack/tsconfig.json
+++ b/webpack/tsconfig.json
@@ -17,7 +17,11 @@
   "exclude": [
     "../../**/*.test.ts",
     "../../**/*.test.tsx",
+    "../../**/test/*.ts",
+    "../../**/test/*.tsx",
     "node_modules/@folio/**/*.test.ts",
-    "node_modules/@folio/**/*.test.tsx"
+    "node_modules/@folio/**/*.test.tsx",
+    "node_modules/@folio/**/test/*.ts",
+    "node_modules/@folio/**/test/*.tsx"
   ]
 }

--- a/webpack/tsconfig.json
+++ b/webpack/tsconfig.json
@@ -17,11 +17,11 @@
   "exclude": [
     "../../**/*.test.ts",
     "../../**/*.test.tsx",
-    "../../**/test/*.ts",
-    "../../**/test/*.tsx",
+    "../../**/test/**/*.ts",
+    "../../**/test/**/*.tsx",
     "node_modules/@folio/**/*.test.ts",
     "node_modules/@folio/**/*.test.tsx",
-    "node_modules/@folio/**/test/*.ts",
-    "node_modules/@folio/**/test/*.tsx"
+    "node_modules/@folio/**/test/**/*.ts",
+    "node_modules/@folio/**/test/**/*.tsx"
   ]
 }


### PR DESCRIPTION
Somehow, TS test files are leaking into the bundle and then causing
errors during the "build" phase when their (dev) dependencies aren't
satisfied. It isn't really clear why they're leaking in, but this PR
makes sure they stay out.

Refs [STRWEB-60](https://issues.folio.org/browse/STRWEB-60)