### PR TITLE
STRWEB-61 Lock enhanced-resolve to ~5.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,12 +86,12 @@
     "mocha-junit-reporter": "^1.17.0",
     "sinon": "^7.3.2",
     "sinon-chai": "^3.3.0",
-    "webpack": "^5.75.0"
+    "webpack": "^5.58.1"
   },
   "peerDependencies": {
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "webpack": "^5.75.0"
+    "webpack": "^5.58.1"
   },
   "resolutions": {
     "enhanced-resolve": "~5.10.0"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "svgo": "^1.2.2",
     "svgo-loader": "^2.2.1",
     "tapable": "^1.0.0",
-    "ts-loader": "^8.2.0",
+    "ts-loader": "^9.4.1",
     "typescript": "^4.2.4",
     "util-ex": "^0.3.15",
     "webpack-dev-middleware": "^5.2.1",
@@ -86,11 +86,14 @@
     "mocha-junit-reporter": "^1.17.0",
     "sinon": "^7.3.2",
     "sinon-chai": "^3.3.0",
-    "webpack": "^5.58.1"
+    "webpack": "^5.75.0"
   },
   "peerDependencies": {
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "webpack": "^5.58.1"
+    "webpack": "^5.75.0"
+  },
+  "resolutions": {
+    "enhanced-resolve": "~5.10.0"
   }
 }


### PR DESCRIPTION
Platform complete is currently failing with:

https://jenkins-aws.indexdata.com/job/Automation/job/build-platform-complete-snapshot/13912/consoleText

This is due to the issue with `enhanced-resolve v5.11.0` (thank you @zburke for pointing to it):

https://github.com/webpack/enhanced-resolve/issues/362

This PR locks `enhanced-resolve` to `"~5.10.0"` it also upgrades `ts-loader` to make sure a single version of `enhanced-resolve` is used in the dependency tree.

Fixes [STRWEB-61](https://issues.folio.org/browse/STRWEB-61)