### PR TITLE
STRWEB-65: Register stripes-ui with stripes-duplicate and stripes-translations plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-webpack
 
+## 4.2.0 IN PROGRESS
+
+* Register `@folio/stripes-ui` with `stripes-duplicate` and `stripes-translations` plugins. Refs STRWEB-65.
+
 ## [4.1.1](https://github.com/folio-org/stripes-webpack/tree/v4.1.1) (2022-11-02)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v4.1.0...v4.1.1)
 

--- a/webpack/stripes-duplicate-plugin.js
+++ b/webpack/stripes-duplicate-plugin.js
@@ -14,6 +14,7 @@ const duplicatesNotAllowed = [
   'rxjs',
   'stripes',
   'stripes-core',
+  'stripes-ui',
   'stripes-components',
   'stripes-connect',
   'stripes-final-form',

--- a/webpack/stripes-translations-plugin.js
+++ b/webpack/stripes-translations-plugin.js
@@ -22,6 +22,7 @@ module.exports = class StripesTranslationPlugin {
       '@folio/stripes-components': {},
       '@folio/stripes-smart-components': {},
       '@folio/stripes-form': {},
+      '@folio/stripes-ui': {},
     };
     Object.assign(this.modules, options.modules);
     this.languageFilter = options.config.languages || [];


### PR DESCRIPTION
https://issues.folio.org/browse/STRWEB-65

While working on https://issues.folio.org/browse/STRIPESUI-2 I noticed that the translations located in `stripes-ui` are not being processed correctly. 

This PR adds `@folio/stripes-ui` to `stripes-translations` and `stripes-duplicate` plugins. 
