### PR TITLE
STRWEB-62: Remove enhanced-resolve resolutions entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 4.2.0 IN PROGRESS
 
 * Register `@folio/stripes-ui` with `stripes-duplicate` and `stripes-translations` plugins. Refs STRWEB-65.
+* Remove `enhanced-resolve` resolutions entry. Refs STRWEB-62.
 
 ## [4.1.1](https://github.com/folio-org/stripes-webpack/tree/v4.1.1) (2022-11-02)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v4.1.0...v4.1.1)

--- a/package.json
+++ b/package.json
@@ -92,8 +92,5 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "webpack": "^5.58.1"
-  },
-  "resolutions": {
-    "enhanced-resolve": "~5.10.0"
   }
 }


### PR DESCRIPTION
https://issues.folio.org/browse/STRWEB-62

This PR reverts the changes from https://github.com/folio-org/stripes-webpack/pull/81 since this was fixed directly in webpack: https://github.com/webpack/enhanced-resolve/pull/364