### PR TITLE
STRWEB-72 bump css-minimizer-webpack-plugin to v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-webpack
 
+## 4.3.0 IN PROGRESS
+
+* Upgrade `css-minimizer-webpack-plugin` to `v4`. Refs STRWEB-72.
+
 ## [4.2.0](https://github.com/folio-org/stripes-webpack/tree/v4.2.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v4.1.2...v4.2.0)
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "core-js": "^3.6.1",
     "crypto-browserify": "^3.12.0",
     "css-loader": "^6.4.0",
-    "css-minimizer-webpack-plugin": "3.1.1",
+    "css-minimizer-webpack-plugin": "^4.2.2",
     "csv-loader": "^3.0.3",
     "debug": "^4.0.1",
     "express": "^4.14.0",


### PR DESCRIPTION
Bump from v3 to v4 to avoid deprecated transitive dependencies.

Refs [STRWEB-72](https://issues.folio.org/browse/STRWEB-72)