### PR TITLE
STRWEB-73 remove babel-plugin-lodash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 4.3.0 IN PROGRESS
 
 * Upgrade `css-minimizer-webpack-plugin` to `v4`. Refs STRWEB-72.
+* Remove `babel-plugin-lodash`. Refs STRWEB-73.
 
 ## [4.2.0](https://github.com/folio-org/stripes-webpack/tree/v4.2.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v4.1.2...v4.2.0)

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "add-asset-html-webpack-plugin": "^5.0.2",
     "autoprefixer": "^10.4.13",
     "babel-loader": "^8.0.0",
-    "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-remove-jsx-attributes": "^0.0.2",
     "buffer": "^6.0.3",
     "commander": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "handlebars-loader": "^1.7.1",
     "html-webpack-plugin": "^5.3.2",
     "lodash": "^4.17.21",
-    "lodash-webpack-plugin": "^0.11.6",
     "mini-css-extract-plugin": "^1.6.2",
     "node-object-hash": "^1.2.0",
     "postcss": "^8.4.2",

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -3,7 +3,6 @@ const fs = require('fs');
 const webpack = require('webpack');
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
 const { generateStripesAlias } = require('./webpack/module-paths');
 const babelLoaderRule = require('./webpack/babel-loader-rule');
 const typescriptLoaderRule = require('./webpack/typescript-loader-rule');
@@ -61,27 +60,6 @@ module.exports = {
       template: fs.existsSync('index.html') ? 'index.html' : `${__dirname}/index.html`,
     }),
     new webpack.EnvironmentPlugin(['NODE_ENV']),
-    // https://github.com/lodash/lodash-webpack-plugin#feature-sets
-    // Replace lodash feature sets of modules with noop.
-    // Feature sets that are truly not needed can be disabled here (listed largest to smallest):
-    new LodashModuleReplacementPlugin({
-      'shorthands': true,
-      'cloning': true,
-      'currying': true,
-      'caching': true,
-      'collections': true,
-      'exotics': true,
-      'guards': true,
-      'metadata': true, // (requires currying)
-      'deburring': true,
-      'unicode': true,
-      'chaining': true,
-      'memoizing': true,
-      'coercions': true,
-      'flattening': true,
-      'paths': true,
-      'placeholders': true // (requires currying)
-    })
   ],
   module: {
     rules: [

--- a/webpack/babel-options.js
+++ b/webpack/babel-options.js
@@ -10,7 +10,6 @@ module.exports = {
     ['@babel/preset-typescript'],
   ],
   plugins: [
-    ['lodash'],
     ['@babel/plugin-proposal-decorators', { 'legacy': true }],
     // when building a platform directly, i.e. outside a workspace,
     // babel complains loudly and repeatedly that when these modules are enabled:


### PR DESCRIPTION
This unmaintained plugin now spews thousands of lines of alerts during install due to one of the webpack functions it leverages being saddled with a deprecation warning. The fix is utterly trivial, but the maintainers have been silent for weeks, not providing any faith that this will ever be addressed.

It was nice to have a small lodash footprint in our bundle, but it felt like a microoptimization given our bundlesize, and something that was not worth the benefit given the poor DX.

This effectively undoes [STRWEB-20](https://issues.folio.org/browse/STRWEB-20)/PR #28

Refs [STRWEB-73](https://issues.folio.org/browse/STRWEB-73)