### PR TITLE
STRWEB-69: Check if @folio/stripes path exists before loading it

### DIFF
--- a/webpack/module-paths.js
+++ b/webpack/module-paths.js
@@ -184,8 +184,13 @@ function getModulesPaths(modules) {
 */
 function getStripesModulesPaths() {
   const packageJsonPath = locatePackageJsonPath('@folio/stripes');
-  const packageJson = require(packageJsonPath);
   const paths = [];
+
+  if (!packageJsonPath) {
+    return paths;
+  }
+
+  const packageJson = require(packageJsonPath);
 
   if (!packageJson) {
     return paths;


### PR DESCRIPTION
This is an additional fix related to transpilation work merged in: https://github.com/folio-org/stripes-webpack/pull/73

The PR adds a check for `@folio/stripes` package.json before loading it.