### PR TITLE
STRWEB-76: Replace babel loader with esbuild loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Upgrade `css-minimizer-webpack-plugin` to `v4`. Refs STRWEB-72.
 * Remove `babel-plugin-lodash`. Refs STRWEB-73.
+* Replace babel loader with esbuild loader. Refs STRWEB-76.
 
 ## [4.2.0](https://github.com/folio-org/stripes-webpack/tree/v4.2.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v4.1.2...v4.2.0)

--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
     "core-js": "^3.6.1",
     "crypto-browserify": "^3.12.0",
     "css-loader": "^6.4.0",
-    "css-minimizer-webpack-plugin": "^4.2.2",
     "csv-loader": "^3.0.3",
     "debug": "^4.0.1",
+    "esbuild-loader": "^3.0.1",
     "express": "^4.14.0",
     "favicons": "^7.0.1",
     "favicons-webpack-plugin": "^6.0.0-alpha.1",
@@ -73,7 +73,6 @@
     "svgo": "^1.2.2",
     "svgo-loader": "^2.2.1",
     "tapable": "^1.0.0",
-    "terser-webpack-plugin": "^5.3.5",
     "ts-loader": "^9.4.1",
     "typescript": "^4.2.4",
     "url-loader": "^4.1.1",
@@ -81,8 +80,7 @@
     "webpack-dev-middleware": "^5.2.1",
     "webpack-hot-middleware": "^2.25.1",
     "webpack-remove-empty-scripts": "^1.0.1",
-    "webpack-virtual-modules": "^0.4.3",
-    "esbuild-loader": "^3.0.1"
+    "webpack-virtual-modules": "^0.4.3"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "webpack-dev-middleware": "^5.2.1",
     "webpack-hot-middleware": "^2.25.1",
     "webpack-remove-empty-scripts": "^1.0.1",
-    "webpack-virtual-modules": "^0.4.3"
+    "webpack-virtual-modules": "^0.4.3",
+    "esbuild-loader": "^3.0.1"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/test/webpack/esbuild-loader-rule.spec.js
+++ b/test/webpack/esbuild-loader-rule.spec.js
@@ -1,5 +1,5 @@
 const expect = require('chai').expect;
-const babelLoaderRule = require('../../webpack/babel-loader-rule');
+const babelLoaderRule = require('../../webpack/esbuild-loader-rule');
 
 describe('The babel-loader-rule', function () {
   describe('test condition function', function () {

--- a/webpack.config.cli.dev.js
+++ b/webpack.config.cli.dev.js
@@ -6,7 +6,7 @@ const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin'
 
 const { getModulesPaths, getStripesModulesPaths } = require('./webpack/module-paths');
 const { tryResolve } = require('./webpack/module-paths');
-const babelLoaderRule = require('./webpack/babel-loader-rule');
+const esbuildLoaderRule = require('./webpack/esbuild-loader-rule');
 const utils = require('./webpack/utils');
 const buildBaseConfig = require('./webpack.config.base');
 const cli = require('./webpack.config.cli');
@@ -62,7 +62,7 @@ const buildConfig = (stripesConfig) => {
   devConfig.resolve.alias.process = 'process/browser.js';
   devConfig.resolve.alias['mocha'] = useBrowserMocha();
 
-  devConfig.module.rules.push(babelLoaderRule(allModulePaths));
+  devConfig.module.rules.push(esbuildLoaderRule(allModulePaths));
 
   // add 'Buffer' global required for tests/reporting tools.
   devConfig.plugins.push(

--- a/webpack.config.cli.prod.js
+++ b/webpack.config.cli.prod.js
@@ -8,7 +8,7 @@ const SpeedMeasurePlugin = require('speed-measure-webpack-plugin');
 
 const buildBaseConfig = require('./webpack.config.base');
 const cli = require('./webpack.config.cli');
-const babelLoaderRule = require('./webpack/babel-loader-rule');
+const esbuildLoaderRule = require('./webpack/esbuild-loader-rule');
 const { getModulesPaths, getStripesModulesPaths, getTranspiledModules } = require('./webpack/module-paths');
 
 const buildConfig = (stripesConfig) => {
@@ -59,7 +59,7 @@ const buildConfig = (stripesConfig) => {
     },
   }
 
-  prodConfig.module.rules.push(babelLoaderRule(allModulePaths));
+  prodConfig.module.rules.push(esbuildLoaderRule(allModulePaths));
 
   const webpackConfig = smp.wrap({ plugins: prodConfig.plugins });
   webpackConfig.plugins.push(

--- a/webpack.config.cli.prod.js
+++ b/webpack.config.cli.prod.js
@@ -3,11 +3,9 @@
 
 const webpack = require('webpack');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
-const TerserPlugin = require('terser-webpack-plugin');
-
-const { getSharedStyles } = require('./webpack/module-paths');
+const { EsbuildPlugin } = require('esbuild-loader');
 const SpeedMeasurePlugin = require('speed-measure-webpack-plugin');
+
 const buildBaseConfig = require('./webpack.config.base');
 const cli = require('./webpack.config.cli');
 const babelLoaderRule = require('./webpack/babel-loader-rule');
@@ -40,11 +38,9 @@ const buildConfig = (stripesConfig) => {
   prodConfig.optimization = {
     mangleWasmImports: false,
     minimizer: [
-      new TerserPlugin({
-        // exclude stripes cache group from the minimizer
-        exclude: /stripes/,
+      new EsbuildPlugin({
+        css: true,
       }),
-      new CssMinimizerPlugin(),
     ],
     splitChunks: {
       // Do not process stripes chunk
@@ -61,7 +57,6 @@ const buildConfig = (stripesConfig) => {
         },
       },
     },
-    minimize: true,
   }
 
   prodConfig.module.rules.push(babelLoaderRule(allModulePaths));

--- a/webpack.config.cli.transpile.js
+++ b/webpack.config.cli.transpile.js
@@ -92,7 +92,7 @@ const config = {
 };
 
 config.optimization = {
-  mangleWasmImports: false,
+  mangleWasmImports: true,
   minimizer: [
     new EsbuildPlugin({
       css: true,

--- a/webpack.config.cli.transpile.js
+++ b/webpack.config.cli.transpile.js
@@ -3,8 +3,7 @@
 const path = require('path');
 const webpack = require('webpack');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
-const babelOptions = require('./webpack/babel-options');
+const { EsbuildPlugin } = require('esbuild-loader');
 const { processExternals } = require('./webpack/utils');
 const { defaultExternals } = require('./consts');
 
@@ -25,8 +24,11 @@ const config = {
       {
         test: /\.(js|jsx|ts|tsx)$/,
         exclude: /node_modules/,
-        loader: 'babel-loader',
-        options: babelOptions,
+        loader: 'esbuild-loader',
+        options: {
+          loader: 'tsx',
+          jsx: 'automatic',
+        },
       },
       {
         test: /\.(woff2?)$/,
@@ -90,12 +92,12 @@ const config = {
 };
 
 config.optimization = {
-  mangleWasmImports: true,
+  mangleWasmImports: false,
   minimizer: [
-   '...', // in webpack@5 we can use the '...' syntax to extend existing minimizers
-    new CssMinimizerPlugin(),
+    new EsbuildPlugin({
+      css: true,
+    }),
   ],
-  minimize: true,
 };
 
 config.plugins = [

--- a/webpack/esbuild-loader-rule.js
+++ b/webpack/esbuild-loader-rule.js
@@ -1,6 +1,4 @@
 const path = require('path');
-
-const babelOptions = require('./babel-options');
 const {
   getNonTranspiledModules,
   getTranspiledModules,
@@ -40,7 +38,7 @@ module.exports = (modulePaths) => {
   const folioModulesRegex = new RegExp(`${escapeRegExp(folioModulePath)}(?!.*dist)`);
 
   return {
-    loader: 'babel-loader',
+    loader: 'esbuild-loader',
     test: /\.js$/,
     include: function(modulePath) {
       // exclude empty modules
@@ -77,8 +75,8 @@ module.exports = (modulePaths) => {
       return true;
     },
     options: {
-      cacheDirectory: true,
-      ...babelOptions,
+      loader: 'tsx',
+      jsx: 'automatic',
     },
   };
 };


### PR DESCRIPTION
https://issues.folio.org/browse/STRWEB-76

This PR replaces babel-loader with [esbuild-lodaer](https://github.com/esbuild-kit/esbuild-loader).

The results are pretty good. The time to build a single module took half the time. It's also 5x faster to build the entire platform (snapshot):

| Babel Loader  | Esbuild Loader |
| ------------- | ------------- |
| Single module  |  Single module  |
| ![users-module-babel](https://user-images.githubusercontent.com/63545/227561603-38c021cf-91e1-497d-a34d-19afcb6fb23f.png)  | ![users-module-esbuild](https://user-images.githubusercontent.com/63545/227561700-e53adc8e-f2ea-4828-af73-b20e4db2f460.png)  |
| Platform (snapshot)  |  Platform (snapshot)  |
| ![platform-snapshot-babel](https://user-images.githubusercontent.com/63545/227561908-d9f5790d-8255-4dd4-a934-ca66d3c2494f.png) | ![platform-snapshot-esbuild](https://user-images.githubusercontent.com/63545/227561996-fa927e07-f35d-4b46-915d-ad9418ba70c1.png)|







