### PR TITLE
STRWEB-75 do not strip data-test attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Upgrade `css-minimizer-webpack-plugin` to `v4`. Refs STRWEB-72.
 * Remove `babel-plugin-lodash`. Refs STRWEB-73.
+* Do not strip `data-test` attributes from production builds. Refs STRWEB-75.
 
 ## [4.2.0](https://github.com/folio-org/stripes-webpack/tree/v4.2.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v4.1.2...v4.2.0)

--- a/webpack/babel-options.js
+++ b/webpack/babel-options.js
@@ -28,7 +28,6 @@ module.exports = {
     '@babel/plugin-proposal-throw-expressions',
     '@babel/plugin-syntax-import-meta',
     utils.isDevelopment && require.resolve('react-refresh/babel'),
-    utils.isProduction && ['remove-jsx-attributes', { patterns: [ '^data-test.*$' ] }]
 
   ].filter(Boolean),
 };


### PR DESCRIPTION
Do not strip `data-test-*` attributes from builds. The bloat they add is minimal (0.5%, 40k out of ~7MB in a gzipped bundle)  and the instrumentation they allow is so so so useful.

Discussed and agreed to at [Slack#stripes-architecture on 2023-03-23](https://folio-project.slack.com/archives/CAN13SWBF/p1679628985648489).

Refs [STRWEB-75](https://issues.folio.org/browse/STRWEB-75)