### PR TITLE
STRWEB-79 avoid buggy postcss-loader 7.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Do not strip `data-test` attributes from production builds. Refs STRWEB-75.
 * Switch to asset modules configuration in stripes webpack (removes file-loader, url-loader deps). Refs STRWEB-77.
 * Remove SVGO-dependencies. Replaced by SVGR for loading STCOM SVG's as react-components. Refs STRWEB-77.
+* Avoid buggy `postcss-loader` `v7.2.0` release. Refs STRWEB-79.
 
 ## [4.2.0](https://github.com/folio-org/stripes-webpack/tree/v4.2.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v4.1.2...v4.2.0)

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "postcss-custom-media": "^9.0.1",
     "postcss-custom-properties": "12.1.11",
     "postcss-import": "^15.0.1",
-    "postcss-loader": "^7.0.2",
+    "postcss-loader": "^7.2.1",
     "postcss-media-minmax": "^5.0.0",
     "postcss-nesting": "^10.2.0",
     "postcss-url": "^10.1.3",


### PR DESCRIPTION
`7.2.0` is buggy; require `7.2.1`.

Refs [STRWEB-79](https://issues.folio.org/browse/STRWEB-79)