### PR TITLE
STRWEB-82: Remove css-minimizer-webpack-plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Replace babel loader with esbuild loader. Refs STRWEB-76.
 * Do not strip `data-test` attributes from production builds. Refs STRWEB-75.
 * Avoid buggy `postcss-loader` `v7.2.0` release. Refs STRWEB-79.
+* Remove `css-minimizer-webpack-plugin`. Refs STRWEB-82.
 
 ## [4.2.0](https://github.com/folio-org/stripes-webpack/tree/v4.2.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v4.1.2...v4.2.0)

--- a/webpack.config.cli.transpile.js
+++ b/webpack.config.cli.transpile.js
@@ -3,7 +3,6 @@
 const path = require('path');
 const webpack = require('webpack');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const { EsbuildPlugin } = require('esbuild-loader');
 
 const { processExternals } = require('./webpack/utils');


### PR DESCRIPTION
Remove unused css-minimizer-webpack-plugin. The plugin was removed in https://github.com/folio-org/stripes-webpack/pull/101 but this import was missed which now causes issues during transpilation.

https://issues.folio.org/browse/STRWEB-82

