### PR TITLE
STRWEB-86 Add missing @babel/plugin-* dependencies that are listed in babel-options.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Avoid buggy `postcss-loader` `v7.2.x` releases. Refs STRWEB-79.
 * Bump minimum `favicons` versions to avoid CVE-2023-0842. Refs STRWEB-83.
 * List `peerDependencies` as `externals` during transpilation process. Refs STRWEB-84.
+* Add missing `@babel/plugin-*` dependencies that are listed in `babel-options.js`. Refs STRWEB-86.
 
 ## [4.2.0](https://github.com/folio-org/stripes-webpack/tree/v4.2.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v4.1.2...v4.2.0)

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "@babel/plugin-proposal-export-namespace-from": "^7.0.0",
     "@babel/plugin-proposal-function-sent": "^7.0.0",
     "@babel/plugin-proposal-numeric-separator": "^7.0.0",
+    "@babel/plugin-proposal-private-methods": "^7.18.6",
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.0",
     "@babel/plugin-proposal-throw-expressions": "^7.0.0",
     "@babel/plugin-syntax-import-meta": "^7.0.0",
     "@babel/preset-env": "^7.0.0",


### PR DESCRIPTION
## Description
Add missing @babel/plugin-* dependencies that are listed in babel-options.js
These missing plugins are causing errors in `ui-inventory` tests

## Issues
[STRWEB-86](https://issues.folio.org/browse/STRWEB-86)