### PR TITLE
Upgrade postcss-calc (pairs with STCOM #2063)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * List `peerDependencies` as `externals` during transpilation process. Refs STRWEB-84.
 * Add missing `@babel/plugin-*` dependencies that are listed in `babel-options.js`. Refs STRWEB-86.
 * Correctly set `.css` in `resolve.extensions` array. Refs STRWEB-85.
+* Upgrade `postcss-calc` dependency from 8.2.4 to 9.0.1. Refs STRWEB-88.
 
 ## [4.2.0](https://github.com/folio-org/stripes-webpack/tree/v4.2.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v4.1.2...v4.2.0)

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "mini-css-extract-plugin": "^1.6.2",
     "node-object-hash": "^1.2.0",
     "postcss": "^8.4.2",
-    "postcss-calc": "^8.2.4",
+    "postcss-calc": "^9.0.1",
     "postcss-color-function": "folio-org/postcss-color-function",
     "postcss-custom-media": "^9.0.1",
     "postcss-custom-properties": "12.1.11",


### PR DESCRIPTION
Breaking postcss-calc change: dropped support for node <14