### PR TITLE
STRWEB-85 revert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 * Bump minimum `favicons` versions to avoid CVE-2023-0842. Refs STRWEB-83.
 * List `peerDependencies` as `externals` during transpilation process. Refs STRWEB-84.
 * Add missing `@babel/plugin-*` dependencies that are listed in `babel-options.js`. Refs STRWEB-86.
-* Correctly set `.css` in `resolve.extensions` array. Refs STRWEB-85.
 * Upgrade `postcss-calc` dependency from 8.2.4 to 9.0.1. Refs STRWEB-88.
 
 ## [4.2.0](https://github.com/folio-org/stripes-webpack/tree/v4.2.0) (2023-01-30)

--- a/webpack.config.cli.shared.styles.js
+++ b/webpack.config.cli.shared.styles.js
@@ -13,7 +13,7 @@ module.exports = (config, context) => {
       "stcom-variables": getSharedStyles("lib/variables"),
     };
 
-    config.resolve.extensions.push('.css');
+    config.resolve.extensions.push('css');
   }
 
   return config;


### PR DESCRIPTION
Reverts #107

[STRWEB-85](https://issues.folio.org/browse/STRWEB-85) is the cause behind [ERM-2935](https://issues.folio.org/browse/ERM-2935). We may be able to omit the line in question altogether, but until we can figure out, definitively, if that's true, we just need to revert and get ui-agreements back in business.