### PR TITLE
STRWEB-94 lock esbuild-loader to ~3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Upgrade `postcss-calc` dependency from 8.2.4 to 9.0.1. Refs STRWEB-88.
 * replace `@babel` packages that have moved from "proposed" to "official". Refs STRWEB-87.
 * *BREAKING* Upgrade `react` to `v18.2.0`. Refs STRWEB-92.
+* Lock `esbuild-loader` to `~3.0.0` to avoid problematic `3.1` release. Refs STRWEB-94.
 
 ## [4.2.0](https://github.com/folio-org/stripes-webpack/tree/v4.2.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v4.1.2...v4.2.0)

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "css-loader": "^6.4.0",
     "csv-loader": "^3.0.3",
     "debug": "^4.0.1",
-    "esbuild-loader": "^3.0.1",
+    "esbuild-loader": "~3.0.1",
     "express": "^4.14.0",
     "favicons": "^7.1.2",
     "favicons-webpack-plugin": "^6.0.0",


### PR DESCRIPTION
`esbuild-loader` `v3.1.0` causes build failures in platform-complete across many modules with complaints like,
```
ERROR in ./node_modules/@folio/data-import/src/components/DataFetcher/DataFetcher.js
Module build failed (from ./node_modules/esbuild-loader/dist/index.cjs):
Error: Transform failed with 1 error:
/Users/zburke/temp/platform-complete/node_modules/@folio/data-import/src/components/DataFetcher/DataFetcher.js:59:0:
ERROR: Transforming JavaScript decorators to the configured target environment ("es2015") is not supported yet
    at failureErrorWithLog (/Users/zburke/temp/platform-complete/node_modules/esbuild/lib/main.js:1649:15)
    at /Users/zburke/temp/platform-complete/node_modules/esbuild/lib/main.js:847:29
    at responseCallbacks.<computed> (/Users/zburke/temp/platform-complete/node_modules/esbuild/lib/main.js:703:9)
    at handleIncomingPacket (/Users/zburke/temp/platform-complete/node_modules/esbuild/lib/main.js:762:9)
    at Socket.readFromStdout (/Users/zburke/temp/platform-complete/node_modules/esbuild/lib/main.js:679:7)
    at Socket.emit (node:events:513:28)
    at addChunk (node:internal/streams/readable:315:12)
    at readableAddChunk (node:internal/streams/readable:289:9)
    at Socket.Readable.push (node:internal/streams/readable:228:10)
    at Pipe.onStreamRead (node:internal/stream_base_commons:190:23)
 @ ./node_modules/@folio/data-import/src/components/DataFetcher/index.js 1:0-30 1:0-30
 @ ./node_modules/@folio/data-import/src/components/index.js 11:0-30 11:0-30
 @ ./node_modules/@folio/data-import/src/index.js 41:0-44:22 54:104-132 60:49-60
 @ ./node_modules/stripes-config.js
```

Refs [STRWEB-94](https://issues.folio.org/browse/STRWEB-94)