### PR TITLE
STRWEB-99 bundle stripes-core's service-worker.js

### DIFF
--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -50,10 +50,6 @@ const baseConfig = {
       dependOn: 'stripesConfig',
       import: '@folio/stripes-ui'
     },
-    'service-worker': {
-      import: '@folio/stripes-core/src/service-worker.js',
-      filename: 'service-worker.js',
-    }
   },
   resolve: {
     alias: {

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -50,6 +50,10 @@ const baseConfig = {
       dependOn: 'stripesConfig',
       import: '@folio/stripes-ui'
     },
+    'service-worker': {
+      import: '@folio/stripes-core/src/service-worker.js',
+      filename: 'service-worker.js',
+    }
   },
   resolve: {
     alias: {

--- a/webpack.config.cli.dev.js
+++ b/webpack.config.cli.dev.js
@@ -36,12 +36,34 @@ const buildConfig = (stripesConfig) => {
   });
 
   // Override filename to remove the hash in development due to memory issues (STCOR-296)
-  devConfig.output.filename = 'bundle.js';
-  devConfig.entry = [
-    'webpack-hot-middleware/client',
-    ...devConfig.entry.css,
-    '@folio/stripes-ui',
-  ];
+  devConfig.output.filename = '[name].js';
+  devConfig.entry =
+  {
+    css: devConfig.entry.css,
+    main: [
+      'webpack-hot-middleware/client',
+      '@folio/stripes-ui',
+    ],
+    'service-worker': {
+      import: '@folio/stripes-core/src/service-worker.js',
+      filename: 'service-worker.js',
+    }
+  };
+
+  // in dev-mode when react-refresh-webpack-plugin (hot reload) is in play
+  // and there are multiple entry points on a single page (as there are now
+  // that we have a service-worker), we need to make sure there is only one
+  // runtime instance so that modules are only instantiated once.
+  //
+  // I don't entirely understand what that ^^^^ means, but it's the outcome
+  // of a conversation among the creators of react, pmmmwh, and webpack,
+  // so I ain't gonna argue.
+  //
+  // thanks SO: https://stackoverflow.com/questions/65640449/how-to-solve-chunkloaderror-loading-hot-update-chunk-second-app-failed-in-webpa
+  // and sokra: https://github.com/pmmmwh/react-refresh-webpack-plugin/issues/88#issuecomment-627558799
+  devConfig.optimization = {
+    runtimeChunk: 'single'
+  };
 
   devConfig.plugins = devConfig.plugins.concat([
     new webpack.ProvidePlugin({

--- a/webpack.config.cli.dev.js
+++ b/webpack.config.cli.dev.js
@@ -22,6 +22,7 @@ const buildConfig = (stripesConfig) => {
 
   const base = buildBaseConfig(allModulePaths);
   const devConfig = Object.assign({}, base, cli, {
+    name: 'development',
     devtool: 'inline-source-map',
     mode: 'development',
     cache: {
@@ -36,19 +37,12 @@ const buildConfig = (stripesConfig) => {
   });
 
   // Override filename to remove the hash in development due to memory issues (STCOR-296)
-  devConfig.output.filename = '[name].js';
-  devConfig.entry =
-  {
-    css: devConfig.entry.css,
-    main: [
-      'webpack-hot-middleware/client',
-      '@folio/stripes-ui',
-    ],
-    'service-worker': {
-      import: '@folio/stripes-core/src/service-worker.js',
-      filename: 'service-worker.js',
-    }
-  };
+  devConfig.output.filename = 'bundle.js';
+  devConfig.entry = [
+    'webpack-hot-middleware/client',
+    ...devConfig.entry.css,
+    '@folio/stripes-ui',
+  ];
 
   // in dev-mode when react-refresh-webpack-plugin (hot reload) is in play
   // and there are multiple entry points on a single page (as there are now

--- a/webpack.config.cli.dev.js
+++ b/webpack.config.cli.dev.js
@@ -61,9 +61,9 @@ const buildConfig = (stripesConfig) => {
   //
   // thanks SO: https://stackoverflow.com/questions/65640449/how-to-solve-chunkloaderror-loading-hot-update-chunk-second-app-failed-in-webpa
   // and sokra: https://github.com/pmmmwh/react-refresh-webpack-plugin/issues/88#issuecomment-627558799
-  devConfig.optimization = {
-    runtimeChunk: 'single'
-  };
+  // devConfig.optimization = {
+  //   runtimeChunk: 'single'
+  // };
 
   devConfig.plugins = devConfig.plugins.concat([
     new webpack.ProvidePlugin({

--- a/webpack.config.cli.dev.js
+++ b/webpack.config.cli.dev.js
@@ -44,21 +44,6 @@ const buildConfig = (stripesConfig) => {
     '@folio/stripes-ui',
   ];
 
-  // in dev-mode when react-refresh-webpack-plugin (hot reload) is in play
-  // and there are multiple entry points on a single page (as there are now
-  // that we have a service-worker), we need to make sure there is only one
-  // runtime instance so that modules are only instantiated once.
-  //
-  // I don't entirely understand what that ^^^^ means, but it's the outcome
-  // of a conversation among the creators of react, pmmmwh, and webpack,
-  // so I ain't gonna argue.
-  //
-  // thanks SO: https://stackoverflow.com/questions/65640449/how-to-solve-chunkloaderror-loading-hot-update-chunk-second-app-failed-in-webpa
-  // and sokra: https://github.com/pmmmwh/react-refresh-webpack-plugin/issues/88#issuecomment-627558799
-  // devConfig.optimization = {
-  //   runtimeChunk: 'single'
-  // };
-
   devConfig.plugins = devConfig.plugins.concat([
     new webpack.ProvidePlugin({
       process: 'process/browser.js',

--- a/webpack.config.cli.js
+++ b/webpack.config.cli.js
@@ -9,6 +9,5 @@ module.exports = {
     filename: 'bundle.[name][contenthash].js',
     chunkFilename: 'chunk.[name][chunkhash].js',
     publicPath: '/',
-    clean: true
   },
 };

--- a/webpack.config.service.worker.js
+++ b/webpack.config.service.worker.js
@@ -1,0 +1,31 @@
+const path = require('path');
+
+const config = {
+  name: 'service-worker',
+  mode: 'development',
+  target: 'web',
+  entry: {
+    'service-worker': {
+      import: '@folio/stripes-core/src/service-worker.js',
+      filename: 'service-worker.js',
+    }
+  },
+  output: {
+    path: path.join(__dirname, 'dist'),
+    filename: 'service-worker.js',
+    publicPath: '/',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        loader: 'esbuild-loader',
+        options: {
+          target: 'es2015'
+        }
+      },
+    ]
+  }
+};
+
+module.exports = config;


### PR DESCRIPTION
Include `service-worker.js`, pulled from
`@folio/stripes-core/src/service-worker.js`, in the output bundle so it can be registered via [`navigator.serviceWorker.register(...)`](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers#registering_your_worker).

Refs [STRWEB-99](https://issues.folio.org/browse/STRWEB-99) [FOLIO-3627](https://issues.folio.org/browse/FOLIO-3627)