### PR TITLE
STRWEB-90 omit css alias cruft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Remove SVGO-dependencies. Replaced by SVGR for loading STCOM SVG's as react-components. Refs STRWEB-77.
 * Bump `@svgr/webpack` from `7.0.0` to `8.1.0`.
 * Bump `babel-loader` from `^8.0.0` to `^9.1.3`.
+* Omit CSS alias cruft, leaving `config.resolve.extenssions` alone. Refs STRWEB-90, STRWEB-85.
 
 ## [4.2.0](https://github.com/folio-org/stripes-webpack/tree/v4.2.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v4.1.2...v4.2.0)

--- a/webpack.config.cli.shared.styles.js
+++ b/webpack.config.cli.shared.styles.js
@@ -12,8 +12,6 @@ module.exports = (config, context) => {
       "stcom-interactionStyles": getSharedStyles("lib/sharedStyles/interactionStyles"),
       "stcom-variables": getSharedStyles("lib/variables"),
     };
-
-    config.resolve.extensions.push('css');
   }
 
   return config;


### PR DESCRIPTION
Don't manipulate `config.resolve.extensions` for the benefit of CSS because it appears we're not actually leveraging it anywhere. Additional spot-testing across a variety of applications doesn't show any of the odd problems we saw when we first tried to clean this up in [STRWEB-85](https://issues.folio.org/browse/STRWEB-85).

Refs [STRWEB-90](https://issues.folio.org/browse/STRWEB-90)