### PR TITLE
STRWEB-102 forward stripes-config values to service worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 5.1.0 IN PROGRESS
 
+* Add an entry point for stripes-core's service worker. Refs STRWEB-99.
+* Pass micro-stripes-config to service worker at build-time. Refs STRWEB-102.
+
 ## [5.0.0](https://github.com/folio-org/stripes-webpack/tree/v5.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v4.2.0...v5.0.0)
 

--- a/webpack.config.service.worker.js
+++ b/webpack.config.service.worker.js
@@ -1,31 +1,44 @@
 const path = require('path');
+const VirtualModulesPlugin = require('webpack-virtual-modules');
 
-const config = {
-  name: 'service-worker',
-  mode: 'development',
-  target: 'web',
-  entry: {
-    'service-worker': {
-      import: '@folio/stripes-core/src/service-worker.js',
+const buildConfig = (stripesConfig) => {
+  const { okapi } = stripesConfig;
+  const virtualModules = new VirtualModulesPlugin({
+    'node_modules/micro-stripes-config.js': `module.exports = { okapiUrl: '${okapi.url}', okapiTenant: '${okapi.tenant}' };`,
+  });
+
+  const config = {
+    name: 'service-worker',
+    mode: 'development',
+    target: 'web',
+    entry: {
+      'service-worker': {
+        import: '@folio/stripes-core/src/service-worker.js',
+        filename: 'service-worker.js',
+      }
+    },
+    plugins: [
+      virtualModules
+    ],
+    output: {
+      path: path.join(__dirname, 'dist'),
       filename: 'service-worker.js',
+      publicPath: '/',
+    },
+    module: {
+      rules: [
+        {
+          test: /\.js$/,
+          loader: 'esbuild-loader',
+          options: {
+            target: 'es2015'
+          }
+        },
+      ]
     }
-  },
-  output: {
-    path: path.join(__dirname, 'dist'),
-    filename: 'service-worker.js',
-    publicPath: '/',
-  },
-  module: {
-    rules: [
-      {
-        test: /\.js$/,
-        loader: 'esbuild-loader',
-        options: {
-          target: 'es2015'
-        }
-      },
-    ]
-  }
-};
+  };
 
-module.exports = config;
+  return config;
+}
+
+module.exports = buildConfig;

--- a/webpack/serve.js
+++ b/webpack/serve.js
@@ -24,7 +24,14 @@ module.exports = function serve(stripesConfig, options) {
   return new Promise((resolve) => {
     logger.log('starting serve...');
     const app = express();
+
+    // service worker config
+    // update resolve/resolveLoader in order to find the micro-stripes-config
+    // virtual module configured by buildServiceWorkerConfig()
     const serviceWorkerConfig = buildServiceWorkerConfig(stripesConfig);
+    serviceWorkerConfig.resolve = { modules: ['node_modules', platformModulePath, coreModulePath] };
+    serviceWorkerConfig.resolveLoader = { modules: ['node_modules', platformModulePath, coreModulePath] };
+
     let config = buildConfig(stripesConfig);
 
     config = sharedStylesConfig(config, {});
@@ -72,8 +79,6 @@ module.exports = function serve(stripesConfig, options) {
     app.use(webpackDevMiddleware(stripesCompiler, {
       publicPath: config.output.publicPath,
     }));
-
-
 
     app.use(webpackHotMiddleware(stripesCompiler));
 

--- a/webpack/serve.js
+++ b/webpack/serve.js
@@ -9,7 +9,7 @@ const applyWebpackOverrides = require('./apply-webpack-overrides');
 const logger = require('./logger')();
 const buildConfig = require('../webpack.config.cli.dev');
 const sharedStylesConfig = require('../webpack.config.cli.shared.styles');
-const serviceWorkerConfig = require('../webpack.config.service.worker');
+const buildServiceWorkerConfig = require('../webpack.config.service.worker');
 
 const cwd = path.resolve();
 const platformModulePath = path.join(cwd, 'node_modules');
@@ -24,7 +24,9 @@ module.exports = function serve(stripesConfig, options) {
   return new Promise((resolve) => {
     logger.log('starting serve...');
     const app = express();
+    const serviceWorkerConfig = buildServiceWorkerConfig(stripesConfig);
     let config = buildConfig(stripesConfig);
+
     config = sharedStylesConfig(config, {});
 
     config.plugins.push(new StripesWebpackPlugin({ stripesConfig }));


### PR DESCRIPTION
Use a virtual module to forward some stripes-config values to the
service worker when it is bundled. These values must be compiled in
because global variables in a service worker are volatile and are thus
reset to their default (null) values on each sleep/wake cycle. Thus, the
only way to make these values permanently available is to compile them
in.

h/t @mkuklis and @JohnC-80 who did the heavy lifting here, helping to think through potential solutions and figuring out how to actually implement them in our highly customized build.

Refs [STRWEB-102](https://issues.folio.org/browse/STRWEB-102), [STCOR-759](https://issues.folio.org/browse/STCOR-759)