### PR TITLE
[STRWEB-104] Use latest TypeScript version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Pass micro-stripes-config to service worker at build-time. Refs STRWEB-102.
 * Add postcss-plugin for relative color syntax support for Firefox. Refs STRWEB-103.
 * Lock `favicons` to `7.1.4` due to build failures. Refs STRWEB-105.
+* Update `typescript` from `^4.2.4` to `^5.3.3`. Refs STRWEB-104.
 
 ## [5.0.0](https://github.com/folio-org/stripes-webpack/tree/v5.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v4.2.0...v5.0.0)

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "style-loader": "^3.3.0",
     "tapable": "^1.0.0",
     "ts-loader": "^9.4.1",
-    "typescript": "^4.2.4",
+    "typescript": "^5.3.3",
     "util-ex": "^0.3.15",
     "webpack-dev-middleware": "^5.2.1",
     "webpack-hot-middleware": "^2.25.1",


### PR DESCRIPTION
# [Jira STRWEB-104](https://issues.folio.org/browse/STRWEB-104)

As part of [Jira STRIPES-900](https://issues.folio.org/browse/STRIPES-900), all modules should use one `typescript` version, inherited from this package.  This TS version should be the latest version.

