### PR TITLE
STRWEB-105 lock favicons to v7.1.4 to avoid build failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add an entry point for stripes-core's service worker. Refs STRWEB-99.
 * Pass micro-stripes-config to service worker at build-time. Refs STRWEB-102.
 * Add postcss-plugin for relative color syntax support for Firefox. Refs STRWEB-103.
+* Lock `favicons` to `7.1.4` due to build failures. Refs STRWEB-105.
 
 ## [5.0.0](https://github.com/folio-org/stripes-webpack/tree/v5.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v4.2.0...v5.0.0)

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "debug": "^4.0.1",
     "esbuild-loader": "~3.0.1",
     "express": "^4.14.0",
-    "favicons": "^7.1.2",
+    "favicons": "7.1.4",
     "favicons-webpack-plugin": "^6.0.0",
     "handlebars": "^4.7.7",
     "handlebars-loader": "^1.7.1",


### PR DESCRIPTION
`favicons` `v7.1.5` bumps `sharp` from `v0.32.6` to `v0.33.1` and ain't nothin' building anymore. Jenkins errors look like
```
/home/jenkins/workspace/Automation/build-platform-complete-snapshot/node_modules/favicons-webpack-plugin/src/index.js:656
    throw new Error(
          ^

Error: Could not find the npm peerDependency "favicons".
Please run:
npm i favicons
 - or -
yarn add favicons

Error: Could not load the "sharp" module using the linux-x64 runtime
Possible solutions:
- Ensure optional dependencies can be installed:
    npm install --include=optional sharp
    yarn add sharp --ignore-engines
- Ensure your package manager supports multi-platform installation:
    See https://sharp.pixelplumbing.com/install#cross-platform
- Add platform-specific dependencies:
    npm install --os=linux --cpu=x64 sharp
    npm install --force @img/sharp-linux-x64
- Consult the installation documentation:
    See https://sharp.pixelplumbing.com/install
    at loadFaviconsLibrary (/home/jenkins/workspace/Automation/build-platform-complete-snapshot/node_modules/favicons-webpack-plugin/src/index.js:656:11)
    at #generateFaviconsWebapp (/home/jenkins/workspace/Automation/build-platform-complete-snapshot/node_modules/favicons-webpack-plugin/src/index.js:454:26)
    at #generateFavicons (/home/jenkins/workspace/Automation/build-platform-complete-snapshot/node_modules/favicons-webpack-plugin/src/index.js:376:44)
    at /home/jenkins/workspace/Automation/build-platform-complete-snapshot/node_modules/favicons-webpack-plugin/src/index.js:164:42
    at /home/jenkins/workspace/Automation/build-platform-complete-snapshot/node_modules/favicons-webpack-plugin/src/cache.js:150:5
    at CacheFacade.providePromise (/home/jenkins/workspace/Automation/build-platform-complete-snapshot/node_modules/webpack/lib/CacheFacade.js:341:24)

Node.js v18.17.1
error Command failed with exit code 1.
```
and similar errors occur in local development builds in other OSes.

Refs [STRWEB-105](https://issues.folio.org/browse/STRWEB-105)