### PR TITLE
STRWEB-108 Favicons not injected into html template.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add postcss-plugin for relative color syntax support for Firefox. Refs STRWEB-103.
 * Lock `favicons` to `7.1.4` due to build failures. Refs STRWEB-105.
 * Update `typescript` from `^4.2.4` to `^5.3.3`. Refs STRWEB-104.
+* Resolve issue with favicon referencing by removing `speed-measurer-webpack-plugin` and its wrapping of other webpack plugins. Refs STRWEB-108.
 
 ## [5.0.0](https://github.com/folio-org/stripes-webpack/tree/v5.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v4.2.0...v5.0.0)

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "semver": "^7.1.3",
     "serialize-javascript": "^5.0.0",
     "source-map-loader": "^4.0.0",
-    "speed-measure-webpack-plugin": "^1.5.0",
     "stream-browserify": "^3.0.0",
     "style-loader": "^3.3.0",
     "tapable": "^1.0.0",

--- a/webpack.config.cli.prod.js
+++ b/webpack.config.cli.prod.js
@@ -4,7 +4,6 @@
 const webpack = require('webpack');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { EsbuildPlugin } = require('esbuild-loader');
-const SpeedMeasurePlugin = require('speed-measure-webpack-plugin');
 const buildBaseConfig = require('./webpack.config.base');
 
 const cli = require('./webpack.config.cli');
@@ -27,7 +26,6 @@ const buildConfig = (stripesConfig) => {
 
   const transpiledModules = getTranspiledModules(allModulePaths);
   const transpiledModulesRegex = new RegExp(transpiledModules.join('|'));
-  const smp = new SpeedMeasurePlugin();
 
   prodConfig.plugins = prodConfig.plugins.concat([
     new webpack.ProvidePlugin({
@@ -61,12 +59,11 @@ const buildConfig = (stripesConfig) => {
 
   prodConfig.module.rules.push(esbuildLoaderRule(allModulePaths));
 
-  const webpackConfig = smp.wrap({ plugins: prodConfig.plugins });
-  webpackConfig.plugins.push(
+  prodConfig.plugins.push(
     new MiniCssExtractPlugin({ filename: 'style.[contenthash].css' })
   );
 
-  return { ...prodConfig, ...webpackConfig };
+  return prodConfig;
 };
 
 module.exports = buildConfig;


### PR DESCRIPTION
## Problem
Deployed platforms are not displaying their proper favicons as required by branding configuration from `stripes-cli`. 

## Approach: 
TLDR: Remove usage/plugin-wrapping of `speed-measurer-webpack-plugin`... our implementation caused plugins to be seen as different types. :(

Favicons are implemented in our build system via the `favicons-webpack-plugin`. This ever-so-helpful plugin goes the distance by not only generating favicons for us, it also does the dirty(hacky?) work of digging into the separate instance of `html-webpack-plugin` and injects the appropriate content into the template that you've supplied. In the case of favicons, they end up as a bunch of `link[rel="icon"]`s in the page's base mark-up. In order to affect the configuration/behavior of `html-webpack-plugin`, `favicons-webpack-plugin` hooks into `html-webpack-plugin`'s callback system. `html-webpack-plugin` has some code that lets other plugins do this - and leans on a JS Weakmap in order to ensure only a single unique set of 'hooks' exist for the plugin instance **per compilation**. The uniqueness can only be ensured if the objects are the all the of the same type.

Our current code applies the `favicon-webpack-plugin` via its node API, within the stripes branding plugin. It has to jump through some hoops to gather the supplied branding assets. When we first added `esbuild` to support transpilation and speed up build-times, we employed `speed-measurer-webpack-plugin`. This was employed when we build the production webpack configuration by wrapping all of the currently existing plugins with a `Proxy` class, this causes it to miss the separately added `favicons-webpack-plugin` - and since it isn't wrapped, it's considered a separate process by `html-webpack-plugin` when it comes time to resolve its hook callbacks since the proxied webpack `Compilations` are a different type from standard `Compilations`. The change here removes the `speed-measurer-webpack-plugin` and the accompanying plugin-wrapping, so all compilations can be seen as the same type and `favicons-webpack-plugin`'s callback is triggered appropriately so that it can inject the favicons into the HTML Template.
😅 😅 😅

`favicons-webpack-plugin` sets up other hooks on webpack's own hook system (where it performs actual icon generation) rather than the hooks of another plugin, so those callbacks executed fine.

We could always add `speed-measurer-webpack-plugin` back later, but it will have to be added to a separate place in the pipeline of our configuration.