### PR TITLE
STRWEB-110 ignore order of CSS imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-webpack
 
+## 5.2.0
+
+* Don't worry about the order of CSS imports across modules. Refs STRWEB-110.
+
 ## 5.1.0 IN PROGRESS
 
 * Add an entry point for stripes-core's service worker. Refs STRWEB-99.

--- a/webpack.config.cli.prod.js
+++ b/webpack.config.cli.prod.js
@@ -60,7 +60,7 @@ const buildConfig = (stripesConfig) => {
   prodConfig.module.rules.push(esbuildLoaderRule(allModulePaths));
 
   prodConfig.plugins.push(
-    new MiniCssExtractPlugin({ filename: 'style.[contenthash].css' })
+    new MiniCssExtractPlugin({ filename: 'style.[contenthash].css', ignoreOrder: true })
   );
 
   return prodConfig;


### PR DESCRIPTION
Add `@folio/consortia-settings` to a platform build generates tens of thousands of lines of warnings form mini-css-extract-plugin about its inability to determine what order to assemble its CSS rules in because different files have the imports in a different order.

It seems likely we don't have to worry about this since per-module CSS will be scoped to that module by postcss, and shared CSS will just be in stripes-components, but this could be riskier than I realize, and a better approach may be to try to figure out what is happening in `@folio/consortia-settings` that is different than every other module we've added to the platform so far.

Refs [STRWEB-110](https://folio-org.atlassian.net/browse/STRWEB-110)