### PR TITLE
STRWEB-109 allow loading of arbitrary text files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Don't worry about the order of CSS imports across modules. Refs STRWEB-110.
 * Remove postcss-plugins: postcss-nesting, postcss-custom-properties, postcss-color-function, postcss-calc. Add CSS variables entry point in webpack config. Refs STRWEB-111.
+* Support import of arbitrary text files via `?raw`. Refs STRWEB-109.
 
 ## [5.1.0](https://github.com/folio-org/stripes-webpack/tree/v5.1.0) (2024-03-12)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v5.0.0...v5.1.0)

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -117,6 +117,16 @@ const baseConfig = {
         resourceQuery: /icon/, // stcom icons use this query on the resource.
         use: ['@svgr/webpack']
       },
+      // allow import of arbitrary files as strings by appending `?raw` to the import.
+      // use it like:
+      //   import someString from "./someTxtFile.txt?raw"
+      // see https://github.com/webpack/webpack/discussions/16775#discussioncomment-5233250
+      // see https://webpack.js.org/guides/asset-modules/
+      // this facilitates importing large files as strings, e.g. XSLT
+      {
+        type: 'asset/source',
+        resourceQuery: /raw/,
+      },
     ],
   },
 };


### PR DESCRIPTION
Support `?raw` to load arbitrary text files as strings, permitting, for example, a large XSLT file to be easily imported.

Usage:
```
import txtFile from "./someTxtFile.txt?raw"
```

CC: @mnscholz

Refs [STRWEB-109](https://folio-org.atlassian.net/browse/STRWEB-109)