### PR TITLE
STRWEB-119 GA: omit publishing MD

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -13,4 +13,6 @@ jobs:
       jest-test-command: yarn run test
       sonar-sources: .
       compile-translations: false
+      generate-module-descriptor: false
+      publish-module-descriptor: false
 


### PR DESCRIPTION
There is no module-descriptor here.

Refs [STRWEB-119](https://folio-org.atlassian.net/browse/STRWEB-119), [STRIPES-938](https://folio-org.atlassian.net/browse/STRIPES-938)