### PR TITLE
STRWEB-117 use less strict shared-workflow dep

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -6,7 +6,8 @@ on:
 
 jobs:
   ui:
-    uses: folio-org/.github/.github/workflows/ui.yml@v1.1
+    uses: folio-org/.github/.github/workflows/ui.yml@v1
+    if: github.ref_name == github.event.repository.default_branch || github.event_name != 'push' || github.ref_type == 'tag'
     secrets: inherit
     with:
       jest-enabled: true


### PR DESCRIPTION
* Change from `v1.1` to `v1`, which is the equivalent of migrating from `1.1` to `^1.0.0` to auto-include updates
* Add an if-condition to avoid running duplicate actions (pr and push are logged as separate events :roll_eyes:

Refs [STRWEB-117](https://folio-org.atlassian.net/browse/STRWEB-117)