### PR TITLE
STRWEB-120 remove babel-plugin-remove-jsx-attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 5.3.0 IN PROGRESS
 
+* Remove unused `babel-plugin-remove-jsx-attributes`. Refs STRWEB-120.
+
 ## [5.2.0](https://github.com/folio-org/stripes-webpack/tree/v5.2.0) (2024-10-09)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v5.1.0...v5.2.0)
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "add-asset-html-webpack-plugin": "^6.0.0",
     "autoprefixer": "^10.4.13",
     "babel-loader": "^9.1.3",
-    "babel-plugin-remove-jsx-attributes": "^0.0.2",
     "buffer": "^6.0.3",
     "commander": "^2.9.0",
     "connect-history-api-fallback": "^1.3.0",


### PR DESCRIPTION
`babel-plugin-remove-jsx-attributes` should have been removed in [STRWEB-75](https://folio-org.atlassian.net/browse/STRWEB-75) (PR #94). Now we've discovered a licensing incompatibility, so it not only _can_ be removed but _must_ be.

Refs [STRWEB-120](https://folio-org.atlassian.net/browse/STRWEB-120)