### PR TITLE
STRWEB-127 bump NodeJS to v20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 6.0.0 IN PROGRESS
 
 * Remove unused `babel-plugin-remove-jsx-attributes`. Refs STRWEB-120.
+* *BREAKING* Bump NodeJS to v20. Refs STRWEB-127.
 
 ## [5.2.0](https://github.com/folio-org/stripes-webpack/tree/v5.2.0) (2024-10-09)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v5.1.0...v5.2.0)

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "nyc --reporter=html --report-dir=artifacts/coverage --all mocha --opts ./test/mocha.opts './test/webpack/**/*.js'"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "@babel/core": "^7.9.0",


### PR DESCRIPTION
Bump the minimum NodeJS version to v20 for compliance with the TC's currently-supported-technologies list as well as compatibility with dependencies that state a similar requirement.

Refs [STRWEB-127](https://folio-org.atlassian.net/browse/STRWEB-127)