### PR TITLE
Revert "STRWEB-127 bump NodeJS to v20 (#155)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## 6.0.0 IN PROGRESS
 
 * Remove unused `babel-plugin-remove-jsx-attributes`. Refs STRWEB-120.
-* *BREAKING* Bump NodeJS to v20. Refs STRWEB-127.
 * *BREAKING* Upgrade `@csstools` plugins to current versions. Refs STRWEB-126.
 * Replace `crypto` polyfill with an empty module. Refs STRWEB-130.
 * *BREAKING* remove service-worker handling. Refs STRWEB-125.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "nyc --reporter=html --report-dir=artifacts/coverage --all mocha --opts ./test/mocha.opts './test/webpack/**/*.js'"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=12.0.0"
   },
   "dependencies": {
     "@babel/core": "^7.9.0",


### PR DESCRIPTION
This reverts commit 095f8eff4b3a44ed202c64bf70a4d9b5eab5be84.

The Jenkins nodes where we build platform-complete don't yet have NodeJS v20 and we don't know when it will be available. In the interest of making other changes (which, AFAIK, do directly not rely on NodeJS v20) available ASAP, we are reverting this change until our build nodes can support it.

Refs [STRWEB-127](https://folio-org.atlassian.net/browse/STRWEB-127)