### PR TITLE
STRWEB-147: Add hash salt for scoped classnames for remote bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Adjust `StripesTranslationsPlugin` for working at the module level and including translations from `stripesDeps`. Refs STRIPES-861.
 * Implement module federation functionality for building and serving remote modules. Refs STRIPES-861.
 * Generate an asset manifest for the build. Refs STRWEB-144.
+* Include a hash salt based on module name for mod-fed ui-module builds. Refs STRWEB-147.
 
 ## [6.0.0](https://github.com/folio-org/stripes-webpack/tree/v6.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v5.2.0...v6.0.0)

--- a/webpack.config.federate.remote.js
+++ b/webpack.config.federate.remote.js
@@ -90,6 +90,7 @@ const buildConfig = (metadata, options) => {
               options: {
                 modules: {
                   localIdentName: '[local]---[hash:base64:5]',
+                  localIdentHashSalt: name,
                 },
                 sourceMap: true,
                 importLoaders: 1,

--- a/webpack.config.federate.remote.js
+++ b/webpack.config.federate.remote.js
@@ -90,6 +90,11 @@ const buildConfig = (metadata, options) => {
               options: {
                 modules: {
                   localIdentName: '[local]---[hash:base64:5]',
+                  // A hash salt based on the module name prevents
+                  // classname/style collisions between modules for common
+                  // shared dependencies like any of the stripes-* libraries.
+                  // This is not required in the monolithic builds since style duplication
+                  // is less of a problem there.
                   localIdentHashSalt: name,
                 },
                 sourceMap: true,


### PR DESCRIPTION
## [STRWEB-147](https://folio-org.atlassian.net/browse/STRWEB-147)

In monolithic, synchronously loaded builds, all of the code and asset imports are deduplicated by webpack. Resolution of dependencies is all mapped back to a single source and repeats of that source are excluded.
In lazy, asynchronously loaded builds, webpack strives to ensure that the dependencies for each split 'chunk' of code are present in order for that code to function. In the case of CSS, those boundaries between chunks are not examined for deduplication, thus repeat imports of CSS will happen.
While webpack/postcss does have numerous ways to exclude code from the bundle, these are often either blanket solutions that could potentially remove necessary code, OR, they're specific and require some manually maintained list of dependencies *not to import.
In some cases, typical code removal means don't even work and webpack still *insists that code be put in the bundle.
We have this if a ui-module uses `composes:` to inject a classname from the compose target to its own CSS classnames - 
like this example from `stripes-smart-components`' [`<SearchButton>`](https://github.com/folio-org/stripes-smart-components/blob/main/lib/SearchAndSort/components/SearchButton/SearchButton.css#L4C3-L4C101):
```
composes: boxoffsetsmall from "~@folio/stripes-components/lib/sharedStyles/interactionStyles.css";
```
`css-loader` does have an `exportOnlyLocals`, but this boolean property, if `true`, will not export any actual CSS, only the generated classnames (so almost.)

While actual code removal is nice, but double-edged, the other solution is to make the duplications *not negatively affect things.

The simplest way to do this in mod-fed land is to apply CSS classnames to built CSS that are at the ui-module level. We can do this by plugging in the actual module name to `css-loader`'s classname generation logic via a `localIdentHashSalt` setting.

This produces classnames that are unique per-module for non-singleton, non-'composed' imports i.e. stripes-smart-components (or an stripes-*-components dep)
`stripes-webpack` settings:
```
... name is from the derived, snake-case name of the module-federation remote.
{
              loader: 'css-loader',
              options: {
                modules: {
                  localIdentName: '[local]---[hash:base64:5]',
                  localIdentHashSalt: name,
                },
                sourceMap: true,
                importLoaders: 1,
              },
            },
``` 

ui-bulk-edit/output/styles.css
```
.interactionStyles---O0FRN {
  position: relative;
  outline: none;
  z-index: 1;
}
```
ui-inventory/output/styles.css
```
.interactionStyles---vA6wk {
  position: relative;
  outline: none;
  z-index: 1;
}
```

### More spike results 
Does the  module-federated platform exhibit the same problem as `--lazy`?
#### [STRIPES-1005](https://folio-org.atlassian.net/browse/STRIPES-1005)
`stripes-components` is a `singleton` for the platform - it isn't loaded twice, and so the styles are not loaded twice. Modfed plugin logic is good about truly splitting apart deps. You can see in this screenshot, the CSS for `row---mewP4` are only loaded once, not twice as in the story.
<img width="1677" height="688" alt="image" src="https://github.com/user-attachments/assets/1826a09f-75c4-449c-8430-12a4d2a7c4c2" />

Isolation looking good between `stripes-smart-compontents` SearchField instances (Orders and Inventory)
<img width="1074" height="532" alt="image" src="https://github.com/user-attachments/assets/d8e9c993-d15f-482c-ab4b-eb9e080a60d2" />
<img width="1059" height="547" alt="image" src="https://github.com/user-attachments/assets/b726ad5b-6fad-4a24-a13c-6417b3863555" />


