### PR TITLE
STRWEB-152 bump engines.node to v22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for stripes-webpack
 
-## 6.1.0 IN PROGRESS
+## 7.0.0 IN PROGRESS
 
 * Unlock `esbuild-loader` from `~3.0.0`, bumping to `^4.2.2`. Refs STRWEB-95.
 * Prune dead code, `stripes.js` and its dep `commander`. Refs STRWEB-134.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Include a hash salt based on module name for mod-fed ui-module builds. Refs STRWEB-147.
 * Include `yarn.lock` to avoid future supply chain attacks. Refs STRWEB-149.
 * Omit `favicons-webpack-plugin`, directly forwarding the provided favicon instead. Refs STRWEB-151.
+* *BREAKING* Bump `engines.node` to `v22.0.0`. Refs STRWEB-152.
 
 ## [6.0.0](https://github.com/folio-org/stripes-webpack/tree/v6.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-webpack/compare/v5.2.0...v6.0.0)

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "nyc --reporter=html --report-dir=artifacts/coverage --all mocha --opts ./test/mocha.opts './test/webpack/**/*.js'"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=22.0.0"
   },
   "dependencies": {
     "@babel/core": "^7.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-webpack",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "The webpack config for stripes",
   "license": "Apache-2.0",
   "publishConfig": {


### PR DESCRIPTION
Bump `package.json`'s `engines.node` to `>=22.0.0` in order to be able to receive updates to dependencies that are not compatible with v12 (`serialize-javascript`, `webpack-copy-plugin`).
    
Refs [STRWEB-152](https://folio-org.atlassian.net/browse/STRWEB-152)