### PR TITLE
STRWEB-151 pass stripes-config through to dev build-config

### DIFF
--- a/webpack.config.cli.dev.js
+++ b/webpack.config.cli.dev.js
@@ -20,7 +20,7 @@ const buildConfig = (stripesConfig) => {
   const stripesModulePaths = getStripesModulesPaths();
   const allModulePaths = [...stripesModulePaths, ...modulePaths];
 
-  const base = buildBaseConfig(allModulePaths);
+  const base = buildBaseConfig(allModulePaths, stripesConfig);
   const devOverrides = {
     name: 'development',
     devtool: 'inline-source-map',


### PR DESCRIPTION
This fixes `serve` command failure, as `webpack.config.cli.dev.js` didn't pass the stripesConfig through to the base config's `buildConfig` function.

Prior to  #179 , the base-config didn't have to care about stripesConfig, so it didn't get passed the config when its `buildConfig` function was called... https://github.com/folio-org/stripes-webpack/blob/2ddd418dd00fb7fbc33b7972c93fcd109e40a5aa/webpack.config.base.js#L136

Now that we're reading that to inspect for the existence of the favicon, since it affects what we're passing to HTMLWebpackPlugin, the base config requires the stripes-config when it's called through `serve` functionality.
