### PR TITLE
STRWEB-156 Gracefully handle a missing favicon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## IN PROGRESS
 
 * Supply Personal Data Disclosure form. Refs STRWEB-136.
+* Gracefully handle a missing favicon. Refs STRWEB-156.
 
 ## 7.0.0 IN PROGRESS
 

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -10,6 +10,7 @@ const { generateStripesAlias } = require('./webpack/module-paths');
 const typescriptLoaderRule = require('./webpack/typescript-loader-rule');
 const { isProduction } = require('./webpack/utils');
 const { getTranspiledCssPaths } = require('./webpack/module-paths');
+const defaultBranding = require('./default-assets/branding');
 
 // React doesn't like being included multiple times as can happen when using
 // yarn link. Here we find a more specific path to it by first looking in
@@ -51,7 +52,10 @@ const resolveFaviconPath = (stripesConfig) => {
     }
     return configured;
   }
-  return fs.existsSync(FAVICON_PATH) ? FAVICON_PATH : undefined;
+  if (fs.existsSync(FAVICON_PATH)) {
+    return FAVICON_PATH;
+  }
+  return defaultBranding.favicon.src;
 };
 
 const baseConfig = {

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -9,7 +9,6 @@ const RemoveEmptyScriptsPlugin = require('webpack-remove-empty-scripts');
 const { generateStripesAlias } = require('./webpack/module-paths');
 const typescriptLoaderRule = require('./webpack/typescript-loader-rule');
 const { isProduction } = require('./webpack/utils');
-const isTesting = process.env.NODE_ENV === 'test';
 const { getTranspiledCssPaths } = require('./webpack/module-paths');
 
 // React doesn't like being included multiple times as can happen when using
@@ -43,6 +42,17 @@ const specificReact = generateStripesAlias('react');
 
 
 const FAVICON_PATH = './tenant-assets/folio-favicon.png';
+
+const resolveFaviconPath = (stripesConfig) => {
+  const configured = stripesConfig?.branding?.favicon?.src;
+  if (configured) {
+    if (!fs.existsSync(configured)) {
+      throw new Error(`The favicon ${configured} could not be found.`);
+    }
+    return configured;
+  }
+  return fs.existsSync(FAVICON_PATH) ? FAVICON_PATH : undefined;
+};
 
 const baseConfig = {
   entry: {
@@ -154,15 +164,10 @@ const buildConfig = (modulePaths, stripesConfig) => {
     });
   }
 
-  const faviconPath = stripesConfig?.branding?.favicon?.src || FAVICON_PATH;
-  if (!isTesting && !fs.existsSync(faviconPath)) {
-    throw new Error(`The favicon ${faviconPath} could not be found.`)
-  }
-
   baseConfig.plugins = [
     new HtmlWebpackPlugin({
       template: fs.existsSync('index.html') ? 'index.html' : `${__dirname}/index.html`,
-      favicon: faviconPath,
+      favicon: resolveFaviconPath(stripesConfig),
     }),
     new webpack.EnvironmentPlugin(['NODE_ENV']),
     new RemoveEmptyScriptsPlugin(),

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -47,10 +47,10 @@ const FAVICON_PATH = './tenant-assets/folio-favicon.png';
 const resolveFaviconPath = (stripesConfig) => {
   const configured = stripesConfig?.branding?.favicon?.src;
   if (configured) {
-    if (!fs.existsSync(configured)) {
-      throw new Error(`The favicon ${configured} could not be found.`);
+    if (fs.existsSync(configured)) {
+      return configured;
     }
-    return configured;
+    throw new Error(`The favicon ${configured} could not be found.`);
   }
   if (fs.existsSync(FAVICON_PATH)) {
     return FAVICON_PATH;


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/STRWEB-156

## Purpose

Running `yarn start` (i.e. `stripes serve`) in a module repository without a `stripes.config.js` fails during webpack configuration. The default config does not define `branding.favicon.src`, and the fallback `FAVICON_PATH` is resolved relative to the current working directory, where the asset typically does not exist. As a result, developers have to manually create a `stripes.config.js` or place a favicon at `./tenant-assets/folio-favicon.png` to start a module locally.

#184 worked around this for the test environment by suppressing the missing-favicon error when `NODE_ENV === 'test'`, but the underlying issue remains for `yarn start`. This PR removes that special case and resolves the favicon uniformly across environments.

## Approach

- Introduced `resolveFaviconPath` helper that returns the configured favicon if it exists, the default `FAVICON_PATH` if it exists, or the bundled `default-assets/favicon.svg` otherwise.
- A configured `branding.favicon.src` that does not exist still throws, so a typo in a tenant config remains a hard error.
- Removed the now unused `isTesting` flag.
- Updated `CHANGELOG.md`.
