### PR TITLE
STRWEB-158 Exclude consumer test files from type checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Supply Personal Data Disclosure form. Refs STRWEB-136.
 * Gracefully handle a missing favicon. Refs STRWEB-156.
+* Exclude consumer test files from type checking. Refs STRWEB-158.
 
 ## 7.0.0 IN PROGRESS
 

--- a/webpack/tsconfig.json
+++ b/webpack/tsconfig.json
@@ -35,6 +35,8 @@
     "../node_modules/@folio/**/test/**/*.ts",
     "../node_modules/@folio/**/test/**/*.tsx",
     "../../node_modules/@folio/**/test/**/*.ts",
-    "../../node_modules/@folio/**/test/**/*.tsx"
+    "../../node_modules/@folio/**/test/**/*.tsx",
+    "../../../../src/**/*.test.ts",
+    "../../../../src/**/*.test.tsx"
   ]
 }


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/STRWEB-158

## Purpose

`webpack/tsconfig.json` extends `include` four levels up (`../../../../src/**/*.ts(x)`) to cover a consuming project's source tree, but `exclude` is not extended to the same depth. As a result, consumer test files under `src/` (e.g. `src/components/Foo/Foo.test.tsx`) are pulled into the type-check program created by `fork-ts-checker-webpack-plugin`. A type-only issue in such a file blocks `stripes build`, even though the consumer's own `tsc` may pass. Test files are not part of the production bundle, so including them in the build's type-check program adds little value while creating friction. Excluding them keeps responsibilities cleanly separated between `stripes build` and the consumer's own `tsc --noEmit` / `yarn test`.

## Approach

Add `../../../../src/**/*.test.ts` and `../../../../src/**/*.test.tsx` to the `exclude` list in `webpack/tsconfig.json` to match the depth of the existing `include` patterns.