### PR TITLE
STRWEB-112 improve missing module messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Supply Personal Data Disclosure form. Refs STRWEB-136.
 * Gracefully handle a missing favicon. Refs STRWEB-156.
 * Exclude consumer test files from type checking. Refs STRWEB-158.
+* Mitigate missing module messaging. Refs STRWEB-112.
 
 ## 7.0.0 IN PROGRESS
 

--- a/webpack/stripes-module-parser.js
+++ b/webpack/stripes-module-parser.js
@@ -75,7 +75,7 @@ class StripesModuleParser {
   loadModulePackageJson(context, aliases) {
     const packageJsonFile = modulePaths.locateStripesModule(context, this.moduleName, aliases, 'package.json');
     if (!packageJsonFile) {
-      throw new StripesBuildError(`StripesModuleParser: Unable to locate ${this.moduleName}'s package.json`);
+      throw new StripesBuildError(`StripesModuleParser: Unable to locate ${this.moduleName}'s package.json. Most likely, ${this.moduleName} is listed in 'stripes.config.js' but was not installed because it is missing in 'package.json'.`);
     }
     this.modulePath = packageJsonFile.replace('package.json', '');
     // eslint-disable-next-line global-require,import/no-dynamic-require


### PR DESCRIPTION
When a build fails because the module has been specified in `stripes.config.js` but is missing the corresponding entry in `package.json` that would cause the module to *actually be installed*, just say that.

Refs [STRWEB-112](https://folio-org.atlassian.net/browse/STRWEB-112)