### PR TITLE
STRWEB-64 correctly check for duplicate @folio modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Exclude consumer test files from type checking. Refs STRWEB-158.
 * Mitigate missing module messaging. Refs STRWEB-112.
 * Upgrade `@module-federation/enhanced` from ^2.0.0 to ^2.8.1 removing `axios`. Refs STRWEB-159.
+* Use scoped package-names when checking for duplicates. Refs STRWEB-64.
 
 ## 7.0.0 IN PROGRESS
 

--- a/webpack/stripes-duplicate-plugin.js
+++ b/webpack/stripes-duplicate-plugin.js
@@ -5,22 +5,24 @@
 const DuplicatePackageCheckerPlugin = require('@cerner/duplicate-package-checker-webpack-plugin');
 
 // Module names that must not have duplicates
-const duplicatesNotAllowed = [
+const duplicatesNotAllowed = new Set([
   'react',
   'react-dom',
   'react-intl',
   'react-router',
   'react-router-dom',
   'rxjs',
-  'stripes',
-  'stripes-core',
-  'stripes-ui',
-  'stripes-components',
-  'stripes-connect',
-  'stripes-final-form',
-  'stripes-form',
-  'stripes-smart-components',
-];
+  '@folio/stripes',
+  '@folio/stripes-components',
+  '@folio/stripes-connect',
+  '@folio/stripes-core',
+  '@folio/stripes-final-form',
+  '@folio/stripes-form',
+  '@folio/stripes-smart-components',
+  '@folio/stripes-types',
+  '@folio/stripes-ui',
+  '@folio/stripes-util',
+]);
 
 module.exports = class StripesDuplicatePlugin {
   constructor(options) {
@@ -33,10 +35,9 @@ module.exports = class StripesDuplicatePlugin {
       new DuplicatePackageCheckerPlugin().apply(compiler);
     }
 
-
     // This will error when duplicates of specific modules are found
     new DuplicatePackageCheckerPlugin({
-      exclude: instance => !duplicatesNotAllowed.includes(instance.name),
+      exclude: instance => !duplicatesNotAllowed.has(instance.name),
       verbose: true,
       emitError: true,
     }).apply(compiler);


### PR DESCRIPTION
When checking for duplicate packages, do it correctly by searching for the full package-name, including namespace. Convert from an array to a Set because Sonar asked pretty please. In fact this is a bit of a hint to the source of the original bug: `Array.includes()` vs `String.includes()`. The first matches if an element is an exact match and the latter if an element is a substring.

Refs [STRWEB-64](https://folio-org.atlassian.net/browse/STRWEB-64)